### PR TITLE
Add strategy pattern for different cow health update formulas

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/formulas/ConstantUpdateFormula.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/formulas/ConstantUpdateFormula.java
@@ -1,0 +1,38 @@
+package edu.ucsb.cs156.happiercows.formulas;
+
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ConstantUpdateFormula implements CowHealthUpdateFormula {
+
+    @Override
+    public String getId() {
+        return "constant";
+    }
+
+    @Override
+    public String getName() {
+        return "Constant";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Cow health increases/decreases at a constant rate, controlled by the degradation rate.";
+    }
+
+    @Override
+    public int getOrder() {
+        return 2;
+    }
+
+    @Override
+    public double calculateNewCowHealth(Commons commons, UserCommons user, int totalCows) {
+        if (totalCows < commons.getCarryingCapacity()) {
+            return user.getCowHealth() + commons.getDegradationRate();
+        } else {
+            return user.getCowHealth() - commons.getDegradationRate();
+        }
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/formulas/ConstantUpdateFormula.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/formulas/ConstantUpdateFormula.java
@@ -29,7 +29,7 @@ public class ConstantUpdateFormula implements CowHealthUpdateFormula {
 
     @Override
     public double calculateNewCowHealth(Commons commons, UserCommons user, int totalCows) {
-        if (totalCows < commons.getCarryingCapacity()) {
+        if (totalCows <= commons.getCarryingCapacity()) {
             return user.getCowHealth() + commons.getDegradationRate();
         } else {
             return user.getCowHealth() - commons.getDegradationRate();

--- a/src/main/java/edu/ucsb/cs156/happiercows/formulas/CowHealthUpdateFormula.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/formulas/CowHealthUpdateFormula.java
@@ -11,11 +11,11 @@ import org.springframework.stereotype.Component;
  * Implementations should be annotated with {@link Component} so they can be automatically
  * discovered by {@link CowHealthUpdateFormulas}.
  * <p>
- * {@link #getOrder()} determines the order in which formulas are shown to the user.
+ * {@link #getOrder()} determines the order in which formulas will be shown to the user.
  */
 public interface CowHealthUpdateFormula extends Ordered {
     /**
-     * A unique identifier for this strategy. This should not be changed, as this is what is stored in the database.
+     * A unique identifier for this strategy.
      */
     String getId();
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/formulas/CowHealthUpdateFormula.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/formulas/CowHealthUpdateFormula.java
@@ -1,0 +1,37 @@
+package edu.ucsb.cs156.happiercows.formulas;
+
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
+
+/**
+ * A strategy for updating cow health.
+ * <p>
+ * Implementations should be annotated with {@link Component} so they can be automatically
+ * discovered by {@link CowHealthUpdateFormulas}.
+ * <p>
+ * {@link #getOrder()} determines the order in which formulas are shown to the user.
+ */
+public interface CowHealthUpdateFormula extends Ordered {
+    /**
+     * A unique identifier for this strategy. This should not be changed, as this is what is stored in the database.
+     */
+    String getId();
+
+    /**
+     * A user-friendly name for this formula.
+     */
+    String getName();
+
+    /**
+     * A user-friendly description of this formula.
+     */
+    String getDescription();
+
+    /**
+     * Calculates new cow health using this strategy.
+     * The result will be clamped between 0 and 100.
+     */
+    double calculateNewCowHealth(Commons commons, UserCommons user, int totalCows);
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/formulas/CowHealthUpdateFormulas.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/formulas/CowHealthUpdateFormulas.java
@@ -1,0 +1,31 @@
+package edu.ucsb.cs156.happiercows.formulas;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class CowHealthUpdateFormulas {
+
+    @Autowired
+    private CowHealthUpdateFormula[] formulas;
+
+    public List<CowHealthUpdateFormula> getAll() {
+        return List.of(formulas);
+    }
+
+    public Optional<CowHealthUpdateFormula> getById(String id) {
+        for (CowHealthUpdateFormula formula : formulas) {
+            if (formula.getId().equals(id)) {
+                return Optional.of(formula);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public CowHealthUpdateFormula getDefault() {
+        return formulas[0];
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/formulas/CowHealthUpdateFormulas.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/formulas/CowHealthUpdateFormulas.java
@@ -1,16 +1,30 @@
 package edu.ucsb.cs156.happiercows.formulas;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 
 @Service
+@Slf4j
 public class CowHealthUpdateFormulas {
 
-    @Autowired
     private CowHealthUpdateFormula[] formulas;
+
+    @Autowired
+    public void setFormulas(CowHealthUpdateFormula[] formulas) {
+        this.formulas = formulas;
+
+        var ids = new HashSet<String>();
+        for (var formula : formulas) {
+            if (!ids.add(formula.getId())) {
+                throw new RuntimeException("Multiple cow health update formulas found with id \"" + formula.getId() + "\"");
+            }
+        }
+    }
 
     public List<CowHealthUpdateFormula> getAll() {
         return List.of(formulas);

--- a/src/main/java/edu/ucsb/cs156/happiercows/formulas/CowHealthUpdateFormulas.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/formulas/CowHealthUpdateFormulas.java
@@ -38,8 +38,4 @@ public class CowHealthUpdateFormulas {
         }
         return Optional.empty();
     }
-
-    public CowHealthUpdateFormula getDefault() {
-        return formulas[0];
-    }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/formulas/LinearUpdateFormula.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/formulas/LinearUpdateFormula.java
@@ -1,0 +1,34 @@
+package edu.ucsb.cs156.happiercows.formulas;
+
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LinearUpdateFormula implements CowHealthUpdateFormula {
+
+    @Override
+    public String getId() {
+        return "linear";
+    }
+
+    @Override
+    public String getName() {
+        return "Linear";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Cow health changes proportionally to the number of cows over/under the carrying capacity, controlled by the degradation rate.";
+    }
+
+    @Override
+    public int getOrder() {
+        return 1;
+    }
+
+    @Override
+    public double calculateNewCowHealth(Commons commons, UserCommons user, int totalCows) {
+        return user.getCowHealth() - (totalCows - commons.getCarryingCapacity()) * commons.getDegradationRate();
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/formulas/LinearUpdateFormula.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/formulas/LinearUpdateFormula.java
@@ -19,7 +19,7 @@ public class LinearUpdateFormula implements CowHealthUpdateFormula {
 
     @Override
     public String getDescription() {
-        return "Cow health changes proportionally to the number of cows over/under the carrying capacity, controlled by the degradation rate.";
+        return "Cow health increases/decreases at a rate proportional to the number of cows over/under the carrying capacity, controlled by the degradation rate.";
     }
 
     @Override

--- a/src/main/java/edu/ucsb/cs156/happiercows/formulas/NoopUpdateFormula.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/formulas/NoopUpdateFormula.java
@@ -24,7 +24,7 @@ public class NoopUpdateFormula implements CowHealthUpdateFormula {
 
     @Override
     public int getOrder() {
-        return 1000;
+        return LOWEST_PRECEDENCE;
     }
 
     @Override

--- a/src/main/java/edu/ucsb/cs156/happiercows/formulas/NoopUpdateFormula.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/formulas/NoopUpdateFormula.java
@@ -1,0 +1,34 @@
+package edu.ucsb.cs156.happiercows.formulas;
+
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NoopUpdateFormula implements CowHealthUpdateFormula {
+
+    @Override
+    public String getId() {
+        return "noop";
+    }
+
+    @Override
+    public String getName() {
+        return "Do nothing";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Cow health does not change.";
+    }
+
+    @Override
+    public int getOrder() {
+        return 1000;
+    }
+
+    @Override
+    public double calculateNewCowHealth(Commons commons, UserCommons user, int totalCows) {
+        return user.getCowHealth();
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/formulas/ConstantUpdateFormulaTest.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/formulas/ConstantUpdateFormulaTest.java
@@ -43,6 +43,7 @@ class ConstantUpdateFormulaTest {
                 .cowHealth(50)
                 .build();
 
+        assertEquals(50.1, formula.calculateNewCowHealth(commons, user, 100));
         assertEquals(50.1, formula.calculateNewCowHealth(commons, user, 90));
         assertEquals(50.1, formula.calculateNewCowHealth(commons, user, 80));
     }

--- a/src/test/java/edu/ucsb/cs156/happiercows/formulas/ConstantUpdateFormulaTest.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/formulas/ConstantUpdateFormulaTest.java
@@ -9,6 +9,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class ConstantUpdateFormulaTest {
 
     @Test
+    void check_properties() {
+        var formula = new ConstantUpdateFormula();
+        assertEquals("constant", formula.getId());
+        assertEquals("Constant", formula.getName());
+        assertEquals("Cow health increases/decreases at a constant rate, controlled by the degradation rate.", formula.getDescription());
+    }
+
+    @Test
     void calculateNewCowHealth_decreases_cow_health_by_constant_rate() {
         var formula = new ConstantUpdateFormula();
         var commons = Commons.builder()

--- a/src/test/java/edu/ucsb/cs156/happiercows/formulas/ConstantUpdateFormulaTest.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/formulas/ConstantUpdateFormulaTest.java
@@ -14,6 +14,7 @@ class ConstantUpdateFormulaTest {
         assertEquals("constant", formula.getId());
         assertEquals("Constant", formula.getName());
         assertEquals("Cow health increases/decreases at a constant rate, controlled by the degradation rate.", formula.getDescription());
+        assertEquals(2, formula.getOrder());
     }
 
     @Test

--- a/src/test/java/edu/ucsb/cs156/happiercows/formulas/ConstantUpdateFormulaTest.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/formulas/ConstantUpdateFormulaTest.java
@@ -1,0 +1,41 @@
+package edu.ucsb.cs156.happiercows.formulas;
+
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ConstantUpdateFormulaTest {
+
+    @Test
+    void calculateNewCowHealth_decreases_cow_health_by_constant_rate() {
+        var formula = new ConstantUpdateFormula();
+        var commons = Commons.builder()
+                .degradationRate(0.1)
+                .carryingCapacity(100)
+                .build();
+        var user = UserCommons.builder()
+                .cowHealth(50)
+                .build();
+
+        assertEquals(49.9, formula.calculateNewCowHealth(commons, user, 110));
+        assertEquals(49.9, formula.calculateNewCowHealth(commons, user, 120));
+    }
+
+    @Test
+    void calculateNewCowHealth_increases_cow_health_by_constant_rate() {
+        var formula = new ConstantUpdateFormula();
+        var commons = Commons.builder()
+                .degradationRate(0.1)
+                .carryingCapacity(100)
+                .build();
+        var user = UserCommons.builder()
+                .cowHealth(50)
+                .build();
+
+        assertEquals(50.1, formula.calculateNewCowHealth(commons, user, 90));
+        assertEquals(50.1, formula.calculateNewCowHealth(commons, user, 80));
+    }
+
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/formulas/CowHealthUpdateFormulasTest.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/formulas/CowHealthUpdateFormulasTest.java
@@ -5,11 +5,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = CowHealthUpdateFormulasTest.Config.class)
 class CowHealthUpdateFormulasTest {
 
     @TestConfiguration
@@ -48,11 +50,14 @@ class CowHealthUpdateFormulasTest {
         assertTrue(formula.isEmpty());
     }
 
+
     @Test
-    void noop_formula_is_last() {
-        var formulas = cowHealthUpdateFormulas.getAll();
-        var lastFormula = formulas.get(formulas.size() - 1);
-        assertInstanceOf(NoopUpdateFormula.class, lastFormula);
+    void no_errors_if_no_duplicate() {
+        var formulasService = new CowHealthUpdateFormulas();
+        assertDoesNotThrow(() -> formulasService.setFormulas(new CowHealthUpdateFormula[]{
+                new ConstantUpdateFormula(),
+                new LinearUpdateFormula(),
+        }));
     }
 
     @Test

--- a/src/test/java/edu/ucsb/cs156/happiercows/formulas/CowHealthUpdateFormulasTest.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/formulas/CowHealthUpdateFormulasTest.java
@@ -5,17 +5,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = CowHealthUpdateFormulasTest.Config.class)
 class CowHealthUpdateFormulasTest {
 
-    // config so spring test can find beans in this package
     @TestConfiguration
     @ComponentScan(basePackageClasses = CowHealthUpdateFormulas.class)
     static class Config {
@@ -53,10 +49,18 @@ class CowHealthUpdateFormulasTest {
     }
 
     @Test
-    void noop_config_is_last() {
+    void noop_formula_is_last() {
         var formulas = cowHealthUpdateFormulas.getAll();
         var lastFormula = formulas.get(formulas.size() - 1);
         assertInstanceOf(NoopUpdateFormula.class, lastFormula);
     }
 
+    @Test
+    void errors_if_duplicate_id_found() {
+        var formulasService = new CowHealthUpdateFormulas();
+        assertThrows(RuntimeException.class, () -> formulasService.setFormulas(new CowHealthUpdateFormula[]{
+                new ConstantUpdateFormula(),
+                new ConstantUpdateFormula(),
+        }));
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/formulas/CowHealthUpdateFormulasTest.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/formulas/CowHealthUpdateFormulasTest.java
@@ -1,0 +1,62 @@
+package edu.ucsb.cs156.happiercows.formulas;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = CowHealthUpdateFormulasTest.Config.class)
+class CowHealthUpdateFormulasTest {
+
+    // config so spring test can find beans in this package
+    @TestConfiguration
+    @ComponentScan(basePackageClasses = CowHealthUpdateFormulas.class)
+    static class Config {
+    }
+
+    @Autowired
+    CowHealthUpdateFormulas cowHealthUpdateFormulas;
+
+    @Test
+    void getAll_returns_all_formulas() {
+        var formulas = cowHealthUpdateFormulas.getAll();
+        // not an exhaustive list
+        var expectedClasses = new Class<?>[]{
+                LinearUpdateFormula.class,
+                ConstantUpdateFormula.class,
+                NoopUpdateFormula.class
+        };
+        for (var expectedClass : expectedClasses) {
+            var found = formulas.stream().filter(expectedClass::isInstance).findAny();
+            assertTrue(found.isPresent(), "Expected to find " + expectedClass.getName() + " in formulas");
+        }
+    }
+
+    @Test
+    void getById_returns_formula_if_id_exists() {
+        var formula = cowHealthUpdateFormulas.getById("constant");
+        assertTrue(formula.isPresent());
+        assertInstanceOf(ConstantUpdateFormula.class, formula.get());
+    }
+
+    @Test
+    void getById_returns_empty_if_id_does_not_exist() {
+        var formula = cowHealthUpdateFormulas.getById("does-not-exist");
+        assertTrue(formula.isEmpty());
+    }
+
+    @Test
+    void noop_config_is_last() {
+        var formulas = cowHealthUpdateFormulas.getAll();
+        var lastFormula = formulas.get(formulas.size() - 1);
+        assertInstanceOf(NoopUpdateFormula.class, lastFormula);
+    }
+
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/formulas/LinearUpdateFormulaTest.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/formulas/LinearUpdateFormulaTest.java
@@ -8,6 +8,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class LinearUpdateFormulaTest {
 
+
+    @Test
+    void check_properties() {
+        var formula = new LinearUpdateFormula();
+        assertEquals("linear", formula.getId());
+        assertEquals("Linear", formula.getName());
+        assertEquals("Cow health increases/decreases at a rate proportional to the number of cows over/under the carrying capacity, controlled by the degradation rate.", formula.getDescription());
+    }
+
     @Test
     void calculateNewCowHealth_decreases_proportional_to_cows_over_carrying_rate() {
         var formula = new LinearUpdateFormula();

--- a/src/test/java/edu/ucsb/cs156/happiercows/formulas/LinearUpdateFormulaTest.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/formulas/LinearUpdateFormulaTest.java
@@ -1,0 +1,40 @@
+package edu.ucsb.cs156.happiercows.formulas;
+
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LinearUpdateFormulaTest {
+
+    @Test
+    void calculateNewCowHealth_decreases_proportional_to_cows_over_carrying_rate() {
+        var formula = new LinearUpdateFormula();
+        var commons = Commons.builder()
+                .degradationRate(0.01)
+                .carryingCapacity(100)
+                .build();
+        var user = UserCommons.builder()
+                .cowHealth(50)
+                .build();
+        int totalCows = 110;
+
+        assertEquals(49.9, formula.calculateNewCowHealth(commons, user, totalCows));
+    }
+
+    @Test
+    void calculateNewCowHealth_increases_proportional_to_cows_over_carrying_rate() {
+        var formula = new LinearUpdateFormula();
+        var commons = Commons.builder()
+                .degradationRate(0.01)
+                .carryingCapacity(100)
+                .build();
+        var user = UserCommons.builder()
+                .cowHealth(50)
+                .build();
+        int totalCows = 90;
+
+        assertEquals(50.1, formula.calculateNewCowHealth(commons, user, totalCows));
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/formulas/LinearUpdateFormulaTest.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/formulas/LinearUpdateFormulaTest.java
@@ -15,6 +15,7 @@ class LinearUpdateFormulaTest {
         assertEquals("linear", formula.getId());
         assertEquals("Linear", formula.getName());
         assertEquals("Cow health increases/decreases at a rate proportional to the number of cows over/under the carrying capacity, controlled by the degradation rate.", formula.getDescription());
+        assertEquals(1, formula.getOrder());
     }
 
     @Test

--- a/src/test/java/edu/ucsb/cs156/happiercows/formulas/NoopUpdateFormulaTest.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/formulas/NoopUpdateFormulaTest.java
@@ -8,6 +8,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class NoopUpdateFormulaTest {
 
     @Test
+    void check_properties() {
+        var formula = new NoopUpdateFormula();
+        assertEquals("noop", formula.getId());
+        assertEquals("Do nothing", formula.getName());
+        assertEquals("Cow health does not change.", formula.getDescription());
+    }
+
+    @Test
     void calculateNewCowHealth_does_not_update_health() {
         var formula = new NoopUpdateFormula();
         var user = UserCommons.builder()

--- a/src/test/java/edu/ucsb/cs156/happiercows/formulas/NoopUpdateFormulaTest.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/formulas/NoopUpdateFormulaTest.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.happiercows.formulas;
 
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.Ordered;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -13,6 +14,7 @@ class NoopUpdateFormulaTest {
         assertEquals("noop", formula.getId());
         assertEquals("Do nothing", formula.getName());
         assertEquals("Cow health does not change.", formula.getDescription());
+        assertEquals(Ordered.LOWEST_PRECEDENCE, formula.getOrder());
     }
 
     @Test

--- a/src/test/java/edu/ucsb/cs156/happiercows/formulas/NoopUpdateFormulaTest.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/formulas/NoopUpdateFormulaTest.java
@@ -1,0 +1,20 @@
+package edu.ucsb.cs156.happiercows.formulas;
+
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NoopUpdateFormulaTest {
+
+    @Test
+    void calculateNewCowHealth_does_not_update_health() {
+        var formula = new NoopUpdateFormula();
+        var user = UserCommons.builder()
+                .cowHealth(50)
+                .build();
+
+        assertEquals(50, formula.calculateNewCowHealth(null, user, 50));
+        assertEquals(50, formula.calculateNewCowHealth(null, user, 100));
+    }
+}


### PR DESCRIPTION
In this PR, we introduce a strategy pattern to for different cow health update `CowHealthUpdateFormula`, along with a few implementations of this strategy.
This PR only includes adding the strategies; actually using the formula is to be done in future PRs.

The particular usage of this pattern is a bit novel, so feedback is greatly appreciated.

More details on how this works currently:
- This leverages Spring boot's component scanning to discover all implementations of the strategy (see `CowHealthUpdateFormulas`).
- Each formula must have an unique `id` (via `getId`); this id can be stored in the database in future PRs.
- In anticipation of implementing the frontend, the interface also includes `getName` and `getDescription`, providing user-friendly info about these formulas. name and description can be changed independently of id.


EDIT: In hindsight (and a sudden burst of inspiration), it might be simpler/better to use a java `enum`; the "strategy" pattern Phil recommended might not be the best for this purpose. I'll quickly make a separate PR for that.


Closes #14 