### PR TITLE
Use different cow health update strategies in backend

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -8,6 +8,7 @@ import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
 import edu.ucsb.cs156.happiercows.models.CreateCommonsParams;
+import edu.ucsb.cs156.happiercows.models.HealthUpdateStrategyList;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
@@ -162,6 +163,16 @@ public class CommonsController extends ApiController {
         Commons saved = commonsRepository.save(commons);
         String body = mapper.writeValueAsString(saved);
 
+        return ResponseEntity.ok().body(body);
+    }
+
+
+    @ApiOperation(value = "List all cow health update strategies")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all-health-update-strategies")
+    public ResponseEntity<String> listCowHealthUpdateStrategies() throws JsonProcessingException {
+        var result = HealthUpdateStrategyList.create();
+        String body = mapper.writeValueAsString(result);
         return ResponseEntity.ok().body(body);
     }
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -1,37 +1,7 @@
 package edu.ucsb.cs156.happiercows.controllers;
 
-import java.time.LocalDateTime;
-import java.util.Optional;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Iterator;
-import java.util.*;
-import java.util.stream.*;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-
-import lombok.extern.slf4j.Slf4j;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
 import edu.ucsb.cs156.happiercows.entities.User;
@@ -40,204 +10,236 @@ import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
 import edu.ucsb.cs156.happiercows.models.CreateCommonsParams;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
-import edu.ucsb.cs156.happiercows.controllers.ApiController;
+import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Api(description = "Commons")
 @RequestMapping("/api/commons")
 @RestController
 public class CommonsController extends ApiController {
-  @Autowired
-  private CommonsRepository commonsRepository;
+    @Autowired
+    private CommonsRepository commonsRepository;
 
-  @Autowired
-  private UserCommonsRepository userCommonsRepository;
+    @Autowired
+    private UserCommonsRepository userCommonsRepository;
 
-  @Autowired
-  ObjectMapper mapper;
+    @Autowired
+    ObjectMapper mapper;
 
-  @ApiOperation(value = "Get a list of all commons")
-  @GetMapping("/all")
-  public ResponseEntity<String> getCommons() throws JsonProcessingException {
-    log.info("getCommons()...");
-    Iterable<Commons> commons = commonsRepository.findAll();
-    String body = mapper.writeValueAsString(commons);
-    return ResponseEntity.ok().body(body);
-  }
-
-  @ApiOperation(value = "Get a list of all commons and number of cows/users")
-  @GetMapping("/allplus")
-  public ResponseEntity<String> getCommonsPlus() throws JsonProcessingException {
-    log.info("getCommonsPlus()...");
-    Iterable<Commons> commonsListIter = commonsRepository.findAll();
-
-    // convert Iterable to List for the purposes of using a Java Stream & lambda
-    // below
-    List<Commons> commonsList = new ArrayList<Commons>();
-    commonsListIter.forEach(commonsList::add);
-
-    List<CommonsPlus> commonsPlusList1 = commonsList.stream()
-        .map(c -> toCommonsPlus(c))
-        .collect(Collectors.toList());
-
-    ArrayList<CommonsPlus> commonsPlusList = new ArrayList<CommonsPlus>(commonsPlusList1);
-
-    String body = mapper.writeValueAsString(commonsPlusList);
-    return ResponseEntity.ok().body(body);
-  }
-
-  @ApiOperation(value = "Update a commons")
-  @PreAuthorize("hasRole('ROLE_ADMIN')")
-  @PutMapping("/update")
-  public ResponseEntity<String> updateCommons(
-      @ApiParam("commons identifier") @RequestParam long id,
-      @ApiParam("request body") @RequestBody CreateCommonsParams params) {
-    Optional<Commons> existing = commonsRepository.findById(id);
-
-    Commons updated;
-    HttpStatus status;
-
-    if (existing.isPresent()) {
-      updated = existing.get();
-      status = HttpStatus.NO_CONTENT;
-    } else {
-      updated = new Commons();
-      status = HttpStatus.CREATED;
+    @ApiOperation(value = "Get a list of all commons")
+    @GetMapping("/all")
+    public ResponseEntity<String> getCommons() throws JsonProcessingException {
+        log.info("getCommons()...");
+        Iterable<Commons> commons = commonsRepository.findAll();
+        String body = mapper.writeValueAsString(commons);
+        return ResponseEntity.ok().body(body);
     }
 
-    updated.setName(params.getName());
-    updated.setCowPrice(params.getCowPrice());
-    updated.setMilkPrice(params.getMilkPrice());
-    updated.setStartingBalance(params.getStartingBalance());
-    updated.setStartingDate(params.getStartingDate());
-    updated.setShowLeaderboard(params.getShowLeaderboard());
-    updated.setDegradationRate(params.getDegradationRate());
-    updated.setCarryingCapacity(params.getCarryingCapacity());
+    @ApiOperation(value = "Get a list of all commons and number of cows/users")
+    @GetMapping("/allplus")
+    public ResponseEntity<String> getCommonsPlus() throws JsonProcessingException {
+        log.info("getCommonsPlus()...");
+        Iterable<Commons> commonsListIter = commonsRepository.findAll();
 
-    if (params.getDegradationRate() < 0) {
-      throw new IllegalArgumentException("Degradation Rate cannot be negative");
+        // convert Iterable to List for the purposes of using a Java Stream & lambda
+        // below
+        List<Commons> commonsList = new ArrayList<Commons>();
+        commonsListIter.forEach(commonsList::add);
+
+        List<CommonsPlus> commonsPlusList1 = commonsList.stream()
+                .map(c -> toCommonsPlus(c))
+                .collect(Collectors.toList());
+
+        ArrayList<CommonsPlus> commonsPlusList = new ArrayList<CommonsPlus>(commonsPlusList1);
+
+        String body = mapper.writeValueAsString(commonsPlusList);
+        return ResponseEntity.ok().body(body);
     }
 
-    commonsRepository.save(updated);
+    @ApiOperation(value = "Update a commons")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("/update")
+    public ResponseEntity<String> updateCommons(
+            @ApiParam("commons identifier") @RequestParam long id,
+            @ApiParam("request body") @RequestBody CreateCommonsParams params
+    ) {
+        Optional<Commons> existing = commonsRepository.findById(id);
 
-    return ResponseEntity.status(status).build();
-  }
+        Commons updated;
+        HttpStatus status;
 
-  @ApiOperation(value = "Get a specific commons")
-  @PreAuthorize("hasRole('ROLE_USER')")
-  @GetMapping("")
-  public Commons getCommonsById(
-      @ApiParam("id") @RequestParam Long id) throws JsonProcessingException {
+        if (existing.isPresent()) {
+            updated = existing.get();
+            status = HttpStatus.NO_CONTENT;
+        } else {
+            updated = new Commons();
+            status = HttpStatus.CREATED;
+        }
 
-    Commons commons = commonsRepository.findById(id)
-        .orElseThrow(() -> new EntityNotFoundException(Commons.class, id));
+        updated.setName(params.getName());
+        updated.setCowPrice(params.getCowPrice());
+        updated.setMilkPrice(params.getMilkPrice());
+        updated.setStartingBalance(params.getStartingBalance());
+        updated.setStartingDate(params.getStartingDate());
+        updated.setShowLeaderboard(params.getShowLeaderboard());
+        updated.setDegradationRate(params.getDegradationRate());
+        updated.setCarryingCapacity(params.getCarryingCapacity());
+        if (params.getAboveCapacityHealthUpdateStrategy() != null) {
+            updated.setAboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.valueOf(params.getAboveCapacityHealthUpdateStrategy()));
+        }
+        if (params.getBelowCapacityHealthUpdateStrategy() != null) {
+            updated.setBelowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.valueOf(params.getBelowCapacityHealthUpdateStrategy()));
+        }
 
-    return commons;
-  }
+        if (params.getDegradationRate() < 0) {
+            throw new IllegalArgumentException("Degradation Rate cannot be negative");
+        }
 
-  @ApiOperation(value = "Create a new commons")
-  @PreAuthorize("hasRole('ROLE_ADMIN')")
-  @PostMapping(value = "/new", produces = "application/json")
-  public ResponseEntity<String> createCommons(
+        commonsRepository.save(updated);
 
-      @ApiParam("request body") @RequestBody CreateCommonsParams params) throws JsonProcessingException {
-    Commons commons = Commons.builder()
-        .name(params.getName())
-        .cowPrice(params.getCowPrice())
-        .milkPrice(params.getMilkPrice())
-        .startingBalance(params.getStartingBalance())
-        .startingDate(params.getStartingDate())
-        .degradationRate(params.getDegradationRate())
-        .showLeaderboard(params.getShowLeaderboard())
-        .carryingCapacity(params.getCarryingCapacity())
-        .build();
-
-    // throw exception for degradation rate
-    if (params.getDegradationRate() < 0) {
-      throw new IllegalArgumentException("Degradation Rate cannot be negative");
+        return ResponseEntity.status(status).build();
     }
 
-    Commons saved = commonsRepository.save(commons);
-    String body = mapper.writeValueAsString(saved);
+    @ApiOperation(value = "Get a specific commons")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public Commons getCommonsById(
+            @ApiParam("id") @RequestParam Long id) throws JsonProcessingException {
 
-    return ResponseEntity.ok().body(body);
-  }
+        Commons commons = commonsRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Commons.class, id));
 
-  @ApiOperation(value = "Join a commons")
-  @PreAuthorize("hasRole('ROLE_USER')")
-  @PostMapping(value = "/join", produces = "application/json")
-  public ResponseEntity<String> joinCommon(
-    @ApiParam("commonsId") @RequestParam Long commonsId) throws Exception {
-
-    User u = getCurrentUser().getUser();
-    Long userId = u.getId();
-    String username = u.getFullName();
-
-    Commons joinedCommons = commonsRepository.findById(commonsId)
-        .orElseThrow(() -> new EntityNotFoundException(Commons.class, commonsId));
-    Optional<UserCommons> userCommonsLookup = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId);
-
-    if (userCommonsLookup.isPresent()) {
-      // user is already a member of this commons
-      String body = mapper.writeValueAsString(joinedCommons);
-      return ResponseEntity.ok().body(body);
+        return commons;
     }
 
-    UserCommons uc = UserCommons.builder()
-        .commonsId(commonsId)
-        .userId(userId)
-        .username(username)
-        .totalWealth(joinedCommons.getStartingBalance())
-        .numOfCows(0)
-        .cowHealth(100)
-        .build();
+    @ApiOperation(value = "Create a new commons")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping(value = "/new", produces = "application/json")
+    public ResponseEntity<String> createCommons(
+            @ApiParam("request body") @RequestBody CreateCommonsParams params
+    ) throws JsonProcessingException {
 
-    userCommonsRepository.save(uc);
+        var builder = Commons.builder()
+                .name(params.getName())
+                .cowPrice(params.getCowPrice())
+                .milkPrice(params.getMilkPrice())
+                .startingBalance(params.getStartingBalance())
+                .startingDate(params.getStartingDate())
+                .degradationRate(params.getDegradationRate())
+                .showLeaderboard(params.getShowLeaderboard())
+                .carryingCapacity(params.getCarryingCapacity());
 
-    String body = mapper.writeValueAsString(joinedCommons);
-    return ResponseEntity.ok().body(body);
-  }
+        // ok to set null values for these, so old backend still works
+        if (params.getAboveCapacityHealthUpdateStrategy() != null) {
+            builder.aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.valueOf(params.getAboveCapacityHealthUpdateStrategy()));
+        }
+        if (params.getBelowCapacityHealthUpdateStrategy() != null) {
+            builder.belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.valueOf(params.getBelowCapacityHealthUpdateStrategy()));
+        }
 
-  @ApiOperation(value = "Delete a Commons")
-  @PreAuthorize("hasRole('ROLE_ADMIN')")
-  @DeleteMapping("")
-  public Object deleteCommons(
-      @ApiParam("id") @RequestParam Long id) {
+        Commons commons = builder.build();
 
-    Commons foundCommons = commonsRepository.findById(id)
-        .orElseThrow(() -> new EntityNotFoundException(Commons.class, id));
 
-    commonsRepository.deleteById(id);
-    userCommonsRepository.deleteAllByCommonsId(id);
+        // throw exception for degradation rate
+        if (params.getDegradationRate() < 0) {
+            throw new IllegalArgumentException("Degradation Rate cannot be negative");
+        }
 
-    String responseString = String.format("commons with id %d deleted", id);
+        Commons saved = commonsRepository.save(commons);
+        String body = mapper.writeValueAsString(saved);
 
-    return genericMessage(responseString);
+        return ResponseEntity.ok().body(body);
+    }
 
-  }
+    @ApiOperation(value = "Join a commons")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PostMapping(value = "/join", produces = "application/json")
+    public ResponseEntity<String> joinCommon(
+            @ApiParam("commonsId") @RequestParam Long commonsId) throws Exception {
 
-  @ApiOperation("Delete a user from a commons")
-  @PreAuthorize("hasRole('ROLE_ADMIN')")
-  @DeleteMapping("/{commonsId}/users/{userId}")
-  public ResponseEntity<Commons> deleteUserFromCommon(@PathVariable("commonsId") Long commonsId,
-      @PathVariable("userId") Long userId) throws Exception {
+        User u = getCurrentUser().getUser();
+        Long userId = u.getId();
+        String username = u.getFullName();
 
-    Optional<UserCommons> uc = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId);
-    UserCommons userCommons = uc.orElseThrow(() -> new Exception(
-        String.format("UserCommons with commonsId=%d and userId=%d not found.", commonsId, userId)));
+        Commons joinedCommons = commonsRepository.findById(commonsId)
+                .orElseThrow(() -> new EntityNotFoundException(Commons.class, commonsId));
+        Optional<UserCommons> userCommonsLookup = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId);
 
-    userCommonsRepository.deleteById(userCommons.getId());
-    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-  }
+        if (userCommonsLookup.isPresent()) {
+            // user is already a member of this commons
+            String body = mapper.writeValueAsString(joinedCommons);
+            return ResponseEntity.ok().body(body);
+        }
 
-  public CommonsPlus toCommonsPlus(Commons c) {
-    Optional<Integer> numCows = commonsRepository.getNumCows(c.getId());
-    Optional<Integer> numUsers = commonsRepository.getNumUsers(c.getId());
+        UserCommons uc = UserCommons.builder()
+                .commonsId(commonsId)
+                .userId(userId)
+                .username(username)
+                .totalWealth(joinedCommons.getStartingBalance())
+                .numOfCows(0)
+                .cowHealth(100)
+                .build();
 
-    return CommonsPlus.builder()
-        .commons(c)
-        .totalCows(numCows.orElse(0))
-        .totalUsers(numUsers.orElse(0))
-        .build();
-  }
+        userCommonsRepository.save(uc);
+
+        String body = mapper.writeValueAsString(joinedCommons);
+        return ResponseEntity.ok().body(body);
+    }
+
+    @ApiOperation(value = "Delete a Commons")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteCommons(
+            @ApiParam("id") @RequestParam Long id) {
+
+        Commons foundCommons = commonsRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Commons.class, id));
+
+        commonsRepository.deleteById(id);
+        userCommonsRepository.deleteAllByCommonsId(id);
+
+        String responseString = String.format("commons with id %d deleted", id);
+
+        return genericMessage(responseString);
+
+    }
+
+    @ApiOperation("Delete a user from a commons")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("/{commonsId}/users/{userId}")
+    public ResponseEntity<Commons> deleteUserFromCommon(@PathVariable("commonsId") Long commonsId,
+                                                        @PathVariable("userId") Long userId) throws Exception {
+
+        Optional<UserCommons> uc = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId);
+        UserCommons userCommons = uc.orElseThrow(() -> new Exception(
+                String.format("UserCommons with commonsId=%d and userId=%d not found.", commonsId, userId)));
+
+        userCommonsRepository.deleteById(userCommons.getId());
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    public CommonsPlus toCommonsPlus(Commons c) {
+        Optional<Integer> numCows = commonsRepository.getNumCows(c.getId());
+        Optional<Integer> numUsers = commonsRepository.getNumUsers(c.getId());
+
+        return CommonsPlus.builder()
+                .commons(c)
+                .totalCows(numCows.orElse(0))
+                .totalUsers(numUsers.orElse(0))
+                .build();
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -1,42 +1,48 @@
 package edu.ucsb.cs156.happiercows.entities;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-
-import lombok.Data;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import lombok.Builder;
-import lombok.AccessLevel;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Entity(name = "commons")
-public class Commons
-{
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private long id;
+public class Commons {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
 
-  private String name;
-  private double cowPrice;
-  private double milkPrice;
-  private double startingBalance;
-  private LocalDateTime startingDate;
-  private double degradationRate;
-  private boolean showLeaderboard;
-  private int carryingCapacity;
+    private String name;
+    private double cowPrice;
+    private double milkPrice;
+    private double startingBalance;
+    private LocalDateTime startingDate;
+    private boolean showLeaderboard;
 
-  @ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST,CascadeType.REMOVE})
-  @JoinTable(name = "user_commons",
-    joinColumns = @JoinColumn(name = "commons_id", referencedColumnName = "id"),
-    inverseJoinColumns = @JoinColumn(name = "user_id", referencedColumnName = "id"))
-  @JsonIgnore // https://www.baeldung.com/jackson-bidirectional-relationships-and-infinite-recursion
-  private List<User> users;
+    private int carryingCapacity;
+    private double degradationRate;
+
+    // these defaults match old behavior
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private CowHealthUpdateStrategies belowCapacityHealthUpdateStrategy = CowHealthUpdateStrategies.DEFAULT_BELOW_CAPACITY;
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private CowHealthUpdateStrategies aboveCapacityHealthUpdateStrategy = CowHealthUpdateStrategies.DEFAULT_ABOVE_CAPACITY;
+
+    @ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    @JoinTable(name = "user_commons",
+            joinColumns = @JoinColumn(name = "commons_id", referencedColumnName = "id"),
+            inverseJoinColumns = @JoinColumn(name = "user_id", referencedColumnName = "id"))
+    @JsonIgnore // https://www.baeldung.com/jackson-bidirectional-relationships-and-infinite-recursion
+    private List<User> users;
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -1,21 +1,16 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
-import java.util.Optional;
-
-
-import java.util.Iterator;
-import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
-import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 import edu.ucsb.cs156.happiercows.entities.Commons;
-import edu.ucsb.cs156.happiercows.entities.UserCommons;
-import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
 import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
+import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategy;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @AllArgsConstructor
 public class UpdateCowHealthJob implements JobContextConsumer {
@@ -37,16 +32,18 @@ public class UpdateCowHealthJob implements JobContextConsumer {
             ctx.log("Commons " + commons.getName() + ", degradationRate: " + commons.getDegradationRate() + ", carryingCapacity: " + commons.getCarryingCapacity());
 
             int carryingCapacity = commons.getCarryingCapacity();
-            double degradationRate = commons.getDegradationRate();
             Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.getId());
 
-            Integer totalCows = commonsRepository.getNumCows(commons.getId()).orElseThrow(()->new RuntimeException("Error calling getNumCows(" + commons.getId() + ")"));
+            Integer totalCows = commonsRepository.getNumCows(commons.getId()).orElseThrow(() -> new RuntimeException("Error calling getNumCows(" + commons.getId() + ")"));
+
+            var isAboveCapacity = totalCows > carryingCapacity;
+            var cowHealthUpdateStrategy = isAboveCapacity ? commons.getAboveCapacityHealthUpdateStrategy() : commons.getBelowCapacityHealthUpdateStrategy();
 
             for (UserCommons userCommons : allUserCommons) {
-                User user = userRepository.findById(userCommons.getUserId()).orElseThrow(()->new RuntimeException("Error calling userRepository.findById(" + userCommons.getUserId() + ")"));
+                User user = userRepository.findById(userCommons.getUserId()).orElseThrow(() -> new RuntimeException("Error calling userRepository.findById(" + userCommons.getUserId() + ")"));
                 ctx.log("User: " + user.getFullName() + ", numCows: " + userCommons.getNumOfCows() + ", cowHealth: " + userCommons.getCowHealth());
 
-                double newCowHealth = calculateNewCowHealth(userCommons.getCowHealth(), userCommons.getNumOfCows(), totalCows, carryingCapacity, degradationRate);
+                var newCowHealth = calculateNewCowHealthUsingStrategy(cowHealthUpdateStrategy, commons, userCommons, totalCows);
                 ctx.log(" old cow health: " + userCommons.getCowHealth() + ", new cow health: " + newCowHealth);
                 userCommons.setCowHealth(newCowHealth);
                 userCommonsRepository.save(userCommons);
@@ -56,19 +53,14 @@ public class UpdateCowHealthJob implements JobContextConsumer {
         ctx.log("Cow health has been updated!");
     }
 
-    public static double calculateNewCowHealth(
-            double oldCowHealth,
-            int numCows,
-            int totalCows,
-            int carryingCapacity,
-            double degradationRate) {
-        if (totalCows <= carryingCapacity) {
-            // increase cow health but do not exceed 100
-            return Math.min(100, oldCowHealth + (degradationRate));
-        } else {
-            // decrease cow health, don't go lower than 0
-            return Math.max(0, oldCowHealth - Math.min((totalCows - carryingCapacity) * degradationRate, 100));
-        }
+    // exposed for testing
+    public static double calculateNewCowHealthUsingStrategy(
+            CowHealthUpdateStrategy strategy,
+            Commons commons,
+            UserCommons userCommons,
+            int totalCows
+    ) {
+        var health = strategy.calculateNewCowHealth(commons, userCommons, totalCows);
+        return Math.max(0, Math.min(health, 100));
     }
-
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -1,38 +1,32 @@
 package edu.ucsb.cs156.happiercows.models;
 
-import java.time.LocalDateTime;
-import java.util.Collection;
-
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-import org.springframework.format.annotation.NumberFormat;
+import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.NumberFormat;
 
-import org.springframework.security.core.GrantedAuthority;
-
-import edu.ucsb.cs156.happiercows.entities.User;
+import java.time.LocalDateTime;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 public class CreateCommonsParams {
-  private String name;
-  @NumberFormat
-  private double cowPrice;
-  @NumberFormat
-  private double milkPrice;
-  @NumberFormat
-  private double startingBalance;
-  @NumberFormat private double degradationRate;
-  @DateTimeFormat
-  private LocalDateTime startingDate;
-  @Builder.Default
-  private Boolean showLeaderboard = false; 
-  @NumberFormat
-  private int carryingCapacity;
+    private String name;
+    @NumberFormat
+    private double cowPrice;
+    @NumberFormat
+    private double milkPrice;
+    @NumberFormat
+    private double startingBalance;
+    @DateTimeFormat
+    private LocalDateTime startingDate;
+    @Builder.Default
+    private Boolean showLeaderboard = false;
+    @NumberFormat
+    private int carryingCapacity;
+    @NumberFormat
+    private double degradationRate;
+
+    private String aboveCapacityHealthUpdateStrategy;
+    private String belowCapacityHealthUpdateStrategy;
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/HealthUpdateStrategyInfo.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/HealthUpdateStrategyInfo.java
@@ -1,0 +1,13 @@
+package edu.ucsb.cs156.happiercows.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor()
+public class HealthUpdateStrategyInfo {
+    private String name;
+    private String displayName;
+    private String description;
+
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/HealthUpdateStrategyList.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/HealthUpdateStrategyList.java
@@ -1,0 +1,34 @@
+package edu.ucsb.cs156.happiercows.models;
+
+import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Data
+@Builder
+public class HealthUpdateStrategyList {
+    private List<HealthUpdateStrategyInfo> strategies;
+    private String defaultAboveCapacity;
+    private String defaultBelowCapacity;
+
+
+    public static HealthUpdateStrategyList create() {
+        var strategies = CowHealthUpdateStrategies.values();
+        var strategiesAsInfo = Arrays.stream(strategies)
+                .map(strategy -> new HealthUpdateStrategyInfo(
+                        strategy.name(),
+                        strategy.getDisplayName(),
+                        strategy.getDescription()
+                ))
+                .toList();
+
+        return HealthUpdateStrategyList.builder()
+                .strategies(strategiesAsInfo)
+                .defaultAboveCapacity(CowHealthUpdateStrategies.DEFAULT_ABOVE_CAPACITY.name())
+                .defaultBelowCapacity(CowHealthUpdateStrategies.DEFAULT_BELOW_CAPACITY.name())
+                .build();
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategies.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategies.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 
 /**
  * The CowHealthUpdateStrategies enum provides a variety of strategies for updating cow health.
- * 
+ *
  * For information on Java enum's, see the Oracle Java Tutorial on <a href="https://docs.oracle.com/javase/tutorial/java/javaOO/enum.html">Enum Types</a>,
  * which are far more powerful in Java than enums in most other languages.
  */
@@ -41,4 +41,7 @@ public enum CowHealthUpdateStrategies implements CowHealthUpdateStrategy {
 
     private final String displayName;
     private final String description;
+
+    public final static CowHealthUpdateStrategies DEFAULT_ABOVE_CAPACITY = Linear;
+    public final static CowHealthUpdateStrategies DEFAULT_BELOW_CAPACITY = Constant;
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -8,6 +8,7 @@ import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.models.CreateCommonsParams;
+import edu.ucsb.cs156.happiercows.models.HealthUpdateStrategyList;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
@@ -557,6 +558,19 @@ public class CommonsControllerTests extends ControllerTestCase {
 
         assertEquals(responseMap.get("message"), "Commons with id 18 not found");
         assertEquals(responseMap.get("type"), "EntityNotFoundException");
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void getHealthUpdateStrategiesTest() throws Exception {
+        var response = mockMvc.perform(
+                get("/api/commons/all-health-update-strategies")
+        ).andExpect(status().isOk()).andReturn();
+
+        var expected = HealthUpdateStrategyList.create();
+        var actual = mapper.readValue(response.getResponse().getContentAsString(), HealthUpdateStrategyList.class);
+        assertEquals(expected, actual);
+
     }
 
     @WithMockUser(roles = {"USER"})

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -1,28 +1,18 @@
 package edu.ucsb.cs156.happiercows.controllers;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
+import edu.ucsb.cs156.happiercows.ControllerTestCase;
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.models.CreateCommonsParams;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-
-import java.util.Map;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -31,728 +21,842 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import edu.ucsb.cs156.happiercows.ControllerTestCase;
-import edu.ucsb.cs156.happiercows.entities.Commons;
-
-import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
-import edu.ucsb.cs156.happiercows.entities.UserCommons;
-import edu.ucsb.cs156.happiercows.models.CreateCommonsParams;
-import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
-import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
-import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = CommonsController.class)
 @AutoConfigureDataJpa
 public class CommonsControllerTests extends ControllerTestCase {
 
-  @MockBean
-  UserCommonsRepository userCommonsRepository;
-
-  @MockBean
-  UserRepository userRepository;
-
-  @MockBean
-  CommonsRepository commonsRepository;
-
-  @Autowired
-  private ObjectMapper objectMapper;
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void createCommonsTest() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-
-    Commons commons = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(50.0)
-        .showLeaderboard(false)
-        .carryingCapacity(100)
-        .build();
-
-    CreateCommonsParams parameters = CreateCommonsParams.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(50.0)
-        .showLeaderboard(false)
-        .carryingCapacity(100)
-        .build();
-
-    String requestBody = objectMapper.writeValueAsString(parameters);
-    String expectedResponse = objectMapper.writeValueAsString(commons);
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/new").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isOk())
-        .andReturn();
-
-    verify(commonsRepository, times(1)).save(commons);
-
-    String actualResponse = response.getResponse().getContentAsString();
-    assertEquals(expectedResponse, actualResponse);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void createCommonsTest_zeroDegradation() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-
-    Commons commons = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(0)
-        .showLeaderboard(false)
-        .carryingCapacity(100)
-        .build();
-
-    CreateCommonsParams parameters = CreateCommonsParams.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(0)
-        .showLeaderboard(false)
-        .carryingCapacity(100)
-        .build();
-
-    String requestBody = objectMapper.writeValueAsString(parameters);
-    String expectedResponse = objectMapper.writeValueAsString(commons);
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/new").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isOk())
-        .andReturn();
-
-    verify(commonsRepository, times(1)).save(commons);
-
-    String actualResponse = response.getResponse().getContentAsString();
-    assertEquals(expectedResponse, actualResponse);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void createCommonsTest_withIllegalDegradationRate() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-
-    Commons commons = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(-8.49)
-        .carryingCapacity(100)
-        .build();
-
-    CreateCommonsParams parameters = CreateCommonsParams.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(-8.49)
-        .carryingCapacity(100)
-        .build();
-
-    String requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/new").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isBadRequest()).andReturn();
-
-    Optional<IllegalArgumentException> someException = Optional
-        .ofNullable((IllegalArgumentException) response.getResolvedException());
-
-    assertNotNull(someException.get());
-    assertTrue(someException.get() instanceof IllegalArgumentException);
-  }
-
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void getCommonsTest() throws Exception {
-    List<Commons> expectedCommons = new ArrayList<Commons>();
-    Commons Commons1 = Commons.builder().name("TestCommons1").build();
-
-    expectedCommons.add(Commons1);
-    when(commonsRepository.findAll()).thenReturn(expectedCommons);
-    MvcResult response = mockMvc.perform(get("/api/commons/all").contentType("application/json"))
-        .andExpect(status().isOk()).andReturn();
-
-    verify(commonsRepository, times(1)).findAll();
-
-    String responseString = response.getResponse().getContentAsString();
-    List<Commons> actualCommons = objectMapper.readValue(responseString, new TypeReference<List<Commons>>() {
-    });
-    assertEquals(actualCommons, expectedCommons);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void updateCommonsTest() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-
-    CreateCommonsParams parameters = CreateCommonsParams.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(50.0)
-        .showLeaderboard(true)
-        .carryingCapacity(100)
-        .build();
-
-    Commons commons = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(50.0)
-        .showLeaderboard(true)
-        .carryingCapacity(100)
-        .build();
-
-    String requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    mockMvc
-        .perform(put("/api/commons/update?id=0").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isCreated());
-
-    verify(commonsRepository, times(1)).save(commons);
-
-    parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
-    commons.setMilkPrice(parameters.getMilkPrice());
-    parameters.setDegradationRate(parameters.getDegradationRate() + 1.00);
-    commons.setDegradationRate(parameters.getDegradationRate());
-    parameters.setShowLeaderboard(false);
-    commons.setShowLeaderboard(parameters.getShowLeaderboard());
-    parameters.setCarryingCapacity(123);
-    commons.setCarryingCapacity(parameters.getCarryingCapacity());
-
-    requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.findById(0L))
-        .thenReturn(Optional.of(commons));
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    mockMvc
-        .perform(put("/api/commons/update?id=0").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isNoContent());
-
-    verify(commonsRepository, times(1)).save(commons);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void updateCommonsTest_withDegradationRate_Zero() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-
-    CreateCommonsParams parameters = CreateCommonsParams.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(8.49)
-        .showLeaderboard(false)
-        .carryingCapacity(100)
-        .build();
-
-    Commons commons = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(8.49)
-        .showLeaderboard(false)
-        .carryingCapacity(100)
-        .build();
-
-    String requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    mockMvc
-        .perform(put("/api/commons/update?id=0").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isCreated());
-
-    verify(commonsRepository, times(1)).save(commons);
-
-    parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
-    commons.setMilkPrice(parameters.getMilkPrice());
-    parameters.setDegradationRate(0);
-    commons.setDegradationRate(parameters.getDegradationRate());
-    parameters.setCarryingCapacity(123);
-    commons.setCarryingCapacity(parameters.getCarryingCapacity());
-
-    requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.findById(0L))
-        .thenReturn(Optional.of(commons));
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    mockMvc
-        .perform(put("/api/commons/update?id=0").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isNoContent());
-
-    verify(commonsRepository, times(1)).save(commons);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void updateCommonsTest_withIllegalDegradationRate() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-
-    CreateCommonsParams parameters = CreateCommonsParams.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(8.49)
-        .showLeaderboard(false)
-        .carryingCapacity(100)
-        .build();
-
-    Commons commons = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(8.49)
-        .showLeaderboard(false)
-        .carryingCapacity(100)
-        .build();
-
-    String requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    mockMvc
-        .perform(put("/api/commons/update?id=0").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isCreated());
-
-    verify(commonsRepository, times(1)).save(commons);
-
-    parameters.setDegradationRate(-10);
-    commons.setDegradationRate(parameters.getDegradationRate());
-
-    requestBody = objectMapper.writeValueAsString(parameters);
-
-    when(commonsRepository.findById(0L))
-        .thenReturn(Optional.of(commons));
-
-    when(commonsRepository.save(commons))
-        .thenReturn(commons);
-
-    MvcResult response = mockMvc
-        .perform(put("/api/commons/update?id=0").with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8")
-            .content(requestBody))
-        .andExpect(status().isBadRequest()).andReturn();
-
-    Optional<IllegalArgumentException> someException = Optional
-        .ofNullable((IllegalArgumentException) response.getResolvedException());
-
-    assertNotNull(someException.get());
-    assertTrue(someException.get() instanceof IllegalArgumentException);
-  }
-
-  // This common SHOULD be in the repository
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void getCommonsByIdTest_valid() throws Exception {
-    Commons Commons1 = Commons.builder()
-        .name("TestCommons2")
-        .id(18L)
-        .build();
-
-    when(commonsRepository.findById(eq(18L))).thenReturn(Optional.of(Commons1));
-
-    MvcResult response = mockMvc.perform(get("/api/commons?id=18"))
-        .andExpect(status().isOk()).andReturn();
-
-    verify(commonsRepository, times(1)).findById(eq(18L));
-    String expectedJson = mapper.writeValueAsString(Commons1);
-    String responseString = response.getResponse().getContentAsString();
-    assertEquals(expectedJson, responseString);
-  }
-
-  // This common SHOULD NOT be in the repository
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void getCommonsByIdTest_invalid() throws Exception {
-
-    when(commonsRepository.findById(eq(18L))).thenReturn(Optional.empty());
-
-    MvcResult response = mockMvc.perform(get("/api/commons?id=18"))
-        .andExpect(status().is(404)).andReturn();
-
-    verify(commonsRepository, times(1)).findById(eq(18L));
-
-    Map<String, Object> responseMap = responseToJson(response);
-
-    assertEquals(responseMap.get("message"), "Commons with id 18 not found");
-    assertEquals(responseMap.get("type"), "EntityNotFoundException");
-  }
-
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void joinCommonsTest() throws Exception {
-
-    Commons c = Commons.builder()
-        .id(2L)
-        .name("Example Commons")
-        .build();
-
-    UserCommons uc = UserCommons.builder()
-        .userId(1L)
-        .username("Fake user")
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(0)
-        .cowHealth(100)
-        .build();
-
-    UserCommons ucSaved = UserCommons.builder()
-        .id(17L)
-        .userId(1L)
-        .username("Fake user")
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(0)
-        .cowHealth(100)
-        .build();
-
-    String requestBody = mapper.writeValueAsString(uc);
-
-    when(userCommonsRepository.findByCommonsIdAndUserId(anyLong(), anyLong())).thenReturn(Optional.empty());
-    when(userCommonsRepository.save(eq(uc))).thenReturn(ucSaved);
-    when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
-
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8").content(requestBody))
-        .andExpect(status().isOk()).andReturn();
-
-    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
-    verify(userCommonsRepository, times(1)).save(uc);
-
-    String responseString = response.getResponse().getContentAsString();
-    String cAsJson = mapper.writeValueAsString(c);
-
-    assertEquals(responseString, cAsJson);
-  }
-
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void already_joined_common_test() throws Exception {
-
-    Commons c = Commons.builder()
-        .id(2L)
-        .name("Example Commons")
-        .build();
-
-    UserCommons uc = UserCommons.builder()
-        .userId(1L)
-        .username("1L")
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(1)
-        .build();
-
-    String requestBody = mapper.writeValueAsString(uc);
-
-    // Instead of returning empty, we instead say that it already exists. We
-    // shouldn't create a new entry.
-    when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(uc));
-    when(userCommonsRepository.save(eq(uc))).thenReturn(uc);
-
-    when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
-
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8").content(requestBody))
-        .andExpect(status().isOk()).andReturn();
-
-    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
-
-    String responseString = response.getResponse().getContentAsString();
-    String cAsJson = mapper.writeValueAsString(c);
-
-    assertEquals(responseString, cAsJson);
-  }
-
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void user_commons_exists_but_commons_doesnt_test() throws Exception {
-    UserCommons uc = UserCommons.builder()
-        .userId(1L)
-        .username("1L")
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(1)
-        .build();
-
-    String requestBody = mapper.writeValueAsString(uc);
-
-    when(commonsRepository.findById(eq(2L))).thenReturn(Optional.empty());
-
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8").content(requestBody))
-        .andExpect(status().is(404)).andReturn();
-
-    verify(commonsRepository, times(1)).findById(eq(2L));
-
-    Map<String, Object> responseMap = responseToJson(response);
-
-    assertEquals(responseMap.get("message"), "Commons with id 2 not found");
-    assertEquals(responseMap.get("type"), "EntityNotFoundException");
-  }
-
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void join_and_create_userCommons_for_nonexistent_commons() throws Exception {
-    UserCommons uc = UserCommons.builder()
-        .userId(1L)
-        .username("1L")
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(1)
-        .build();
-
-    UserCommons ucSaved = UserCommons.builder()
-        .id(17L)
-        .userId(1L)
-        .username("2L")
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(1)
-        .build();
-
-    String requestBody = mapper.writeValueAsString(uc);
-
-    when(commonsRepository.findById(eq(2L))).thenReturn(Optional.empty());
-
-    MvcResult response = mockMvc
-        .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8").content(requestBody))
-        .andExpect(status().is(404)).andReturn();
-
-    verify(commonsRepository, times(1)).findById(eq(2L));
-
-    Map<String, Object> responseMap = responseToJson(response);
-
-    assertEquals(responseMap.get("message"), "Commons with id 2 not found");
-    assertEquals(responseMap.get("type"), "EntityNotFoundException");
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void deleteCommons_test_admin_exists() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-
-    Commons c = Commons.builder()
-        .name("Jackson's Commons")
-        .cowPrice(500.99)
-        .milkPrice(8.99)
-        .startingBalance(1020.10)
-        .startingDate(someTime)
-        .degradationRate(50.0)
-        .showLeaderboard(false)
-        .carryingCapacity(100)
-        .build();
-
-    when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
-    doNothing().when(commonsRepository).deleteById(2L);
-    doNothing().when(userCommonsRepository).deleteAllByCommonsId(2L);
-
-    MvcResult response = mockMvc.perform(
-        delete("/api/commons?id=2")
-            .with(csrf()))
-        .andExpect(status().is(200)).andReturn();
-
-    verify(commonsRepository, times(1)).findById(2L);
-    verify(commonsRepository, times(1)).deleteById(2L);
-    verify(userCommonsRepository, times(1)).deleteAllByCommonsId(2L);
-
-    String responseString = response.getResponse().getContentAsString();
-
-    String expectedString = "{\"message\":\"commons with id 2 deleted\"}";
-
-    assertEquals(expectedString, responseString);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void deleteCommons_test_admin_nonexists() throws Exception {
-
-      when(commonsRepository.findById(eq(2L))).thenReturn(Optional.empty());
-
-      MvcResult response = mockMvc.perform(
-              delete("/api/commons?id=2")
-                      .with(csrf()))
-              .andExpect(status().is(404)).andReturn();
-      verify(commonsRepository, times(1)).findById(2L);
-
-
-      String expectedString = "{\"message\":\"Commons with id 2 not found\",\"type\":\"EntityNotFoundException\"}";
-
-      Map<String, Object> expectedJson = mapper.readValue(expectedString,  new TypeReference<Map<String,Object>>() {});
-      Map<String, Object> jsonResponse = responseToJson(response);
-      assertEquals(expectedJson, jsonResponse);
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void deleteUserFromCommonsTest() throws Exception {
-    UserCommons uc = UserCommons.builder()
-        .id(16L)
-        .userId(1L)
-        .username("1L")
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(1)
-        .build();
-
-    String requestBody = mapper.writeValueAsString(uc);
-
-    when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(uc));
-
-    MvcResult response = mockMvc
-        .perform(delete("/api/commons/2/users/1").with(csrf()).contentType(MediaType.APPLICATION_JSON)
-            .characterEncoding("utf-8").content(requestBody))
-        .andExpect(status().is(204)).andReturn();
-
-    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
-    verify(userCommonsRepository, times(1)).deleteById(16L);
-
-    String responseString = response.getResponse().getContentAsString();
-
-    assertEquals(responseString, "");
-  }
-
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void deleteUserFromCommonsTest_nonexistent_userCommons() throws Exception {
-    UserCommons uc = UserCommons.builder()
-        .id(16L)
-        .userId(1L)
-        .username("1L")
-        .commonsId(2L)
-        .totalWealth(0)
-        .numOfCows(1)
-        .build();
-
-    String requestBody = mapper.writeValueAsString(uc);
-
-    when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.empty());
-
-    MvcResult response;
-    try {
-      response = mockMvc
-          .perform(delete("/api/commons/2/users/1").with(csrf()).contentType(MediaType.APPLICATION_JSON)
-              .characterEncoding("utf-8").content(requestBody))
-          .andExpect(status().is(204)).andReturn();
-
-      // The way this works is very interesting. The error message is sent as the
-      // value of a nested exception.
-    } catch (Exception e) {
-      assertEquals(e.toString(),
-          "org.springframework.web.util.NestedServletException: Request processing failed; nested exception is java.lang.Exception: UserCommons with commonsId=2 and userId=1 not found.");
+    @MockBean
+    UserCommonsRepository userCommonsRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @MockBean
+    CommonsRepository commonsRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void createCommonsTest() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(50.0)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant)
+                .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+                .build();
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(50.0)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant.name())
+                .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear.name())
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(parameters);
+        String expectedResponse = objectMapper.writeValueAsString(commons);
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/new").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        verify(commonsRepository, times(1)).save(commons);
+
+        String actualResponse = response.getResponse().getContentAsString();
+        assertEquals(expectedResponse, actualResponse);
     }
-  }
 
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void getCommonsPlusTest() throws Exception {
-    List<Commons> expectedCommons = new ArrayList<Commons>();
-    Commons Commons1 = Commons.builder().name("TestCommons1").id(1L).build();
-    expectedCommons.add(Commons1);
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void createCommonsTest_withNoCowHealthUpdateStrategies() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
 
-    List<CommonsPlus> expectedCommonsPlus = new ArrayList<CommonsPlus>();
-    CommonsPlus CommonsPlus1 = CommonsPlus.builder()
-        .commons(Commons1)
-        .totalCows(50)
-        .totalUsers(20)
-        .build();
+        Commons commons = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(50.0)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .build();
 
-    expectedCommonsPlus.add(CommonsPlus1);
-    when(commonsRepository.findAll()).thenReturn(expectedCommons);
-    when(commonsRepository.getNumCows(1L)).thenReturn(Optional.of(50));
-    when(commonsRepository.getNumUsers(1L)).thenReturn(Optional.of(20));
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(50.0)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .build();
 
-    MvcResult response = mockMvc.perform(get("/api/commons/allplus").contentType("application/json"))
-        .andExpect(status().isOk()).andReturn();
+        // don't include null values to simulate old frontend
+        var mapperWithoutNulls = objectMapper.copy().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        String requestBody = mapperWithoutNulls.writeValueAsString(parameters);
 
-    verify(commonsRepository, times(1)).findAll();
+        String expectedResponse = objectMapper.writeValueAsString(commons);
 
-    String responseString = response.getResponse().getContentAsString();
-    List<CommonsPlus> actualCommonsPlus = objectMapper.readValue(responseString,
-        new TypeReference<List<CommonsPlus>>() {
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/new").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        verify(commonsRepository, times(1)).save(commons);
+
+        String actualResponse = response.getResponse().getContentAsString();
+        assertEquals(expectedResponse, actualResponse);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void createCommonsTest_zeroDegradation() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(0)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .build();
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(0)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(parameters);
+        String expectedResponse = objectMapper.writeValueAsString(commons);
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/new").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        verify(commonsRepository, times(1)).save(commons);
+
+        String actualResponse = response.getResponse().getContentAsString();
+        assertEquals(expectedResponse, actualResponse);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void createCommonsTest_withIllegalDegradationRate() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(-8.49)
+                .carryingCapacity(100)
+                .build();
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(-8.49)
+                .carryingCapacity(100)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/new").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        Optional<IllegalArgumentException> someException = Optional
+                .ofNullable((IllegalArgumentException) response.getResolvedException());
+
+        assertNotNull(someException.get());
+        assertTrue(someException.get() instanceof IllegalArgumentException);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void getCommonsTest() throws Exception {
+        List<Commons> expectedCommons = new ArrayList<Commons>();
+        Commons Commons1 = Commons.builder().name("TestCommons1").build();
+
+        expectedCommons.add(Commons1);
+        when(commonsRepository.findAll()).thenReturn(expectedCommons);
+        MvcResult response = mockMvc.perform(get("/api/commons/all").contentType("application/json"))
+                .andExpect(status().isOk()).andReturn();
+
+        verify(commonsRepository, times(1)).findAll();
+
+        String responseString = response.getResponse().getContentAsString();
+        List<Commons> actualCommons = objectMapper.readValue(responseString, new TypeReference<List<Commons>>() {
         });
-    assertEquals(actualCommonsPlus, expectedCommonsPlus);
-  }
+        assertEquals(actualCommons, expectedCommons);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void updateCommonsTest() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(50.0)
+                .showLeaderboard(true)
+                .carryingCapacity(100)
+                .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant.name())
+                .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear.name())
+                .build();
+
+        Commons commons = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(50.0)
+                .showLeaderboard(true)
+                .carryingCapacity(100)
+                .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant)
+                .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        mockMvc
+                .perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isCreated());
+
+        verify(commonsRepository, times(1)).save(commons);
+
+        parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
+        commons.setMilkPrice(parameters.getMilkPrice());
+        parameters.setDegradationRate(parameters.getDegradationRate() + 1.00);
+        commons.setDegradationRate(parameters.getDegradationRate());
+        parameters.setShowLeaderboard(false);
+        commons.setShowLeaderboard(parameters.getShowLeaderboard());
+        parameters.setCarryingCapacity(123);
+        commons.setCarryingCapacity(parameters.getCarryingCapacity());
+        parameters.setAboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear.name());
+        commons.setAboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear);
+        parameters.setBelowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Noop.name());
+        commons.setBelowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Noop);
+
+        requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.findById(0L))
+                .thenReturn(Optional.of(commons));
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        mockMvc
+                .perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isNoContent());
+
+        verify(commonsRepository, times(1)).save(commons);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void updateCommonsTest_withNoCowHealthUpdateStrategy() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(50.0)
+                .showLeaderboard(true)
+                .carryingCapacity(100)
+                .build();
+
+        Commons commons = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(50.0)
+                .showLeaderboard(true)
+                .carryingCapacity(100)
+                .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant)
+                .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+                .build();
+
+        var objectMapperWithoutNulls = objectMapper.copy()
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        String requestBody = objectMapperWithoutNulls.writeValueAsString(parameters);
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+        when(commonsRepository.findById(0L))
+                .thenReturn(Optional.of(commons));
+
+        mockMvc
+                .perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isNoContent());
+
+        verify(commonsRepository, times(1)).save(commons);
+
+        assertEquals(CowHealthUpdateStrategies.Constant, commons.getAboveCapacityHealthUpdateStrategy());
+        assertEquals(CowHealthUpdateStrategies.Linear, commons.getBelowCapacityHealthUpdateStrategy());
+    }
+
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void updateCommonsTest_withDegradationRate_Zero() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(8.49)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .build();
+
+        Commons commons = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(8.49)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        mockMvc
+                .perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isCreated());
+
+        verify(commonsRepository, times(1)).save(commons);
+
+        parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
+        commons.setMilkPrice(parameters.getMilkPrice());
+        parameters.setDegradationRate(0);
+        commons.setDegradationRate(parameters.getDegradationRate());
+        parameters.setCarryingCapacity(123);
+        commons.setCarryingCapacity(parameters.getCarryingCapacity());
+
+        requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.findById(0L))
+                .thenReturn(Optional.of(commons));
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        mockMvc
+                .perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isNoContent());
+
+        verify(commonsRepository, times(1)).save(commons);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void updateCommonsTest_withIllegalDegradationRate() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        CreateCommonsParams parameters = CreateCommonsParams.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(8.49)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .build();
+
+        Commons commons = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(8.49)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        mockMvc
+                .perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isCreated());
+
+        verify(commonsRepository, times(1)).save(commons);
+
+        parameters.setDegradationRate(-10);
+        commons.setDegradationRate(parameters.getDegradationRate());
+
+        requestBody = objectMapper.writeValueAsString(parameters);
+
+        when(commonsRepository.findById(0L))
+                .thenReturn(Optional.of(commons));
+
+        when(commonsRepository.save(commons))
+                .thenReturn(commons);
+
+        MvcResult response = mockMvc
+                .perform(put("/api/commons/update?id=0").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        Optional<IllegalArgumentException> someException = Optional
+                .ofNullable((IllegalArgumentException) response.getResolvedException());
+
+        assertNotNull(someException.get());
+        assertTrue(someException.get() instanceof IllegalArgumentException);
+    }
+
+    // This common SHOULD be in the repository
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void getCommonsByIdTest_valid() throws Exception {
+        Commons Commons1 = Commons.builder()
+                .name("TestCommons2")
+                .id(18L)
+                .build();
+
+        when(commonsRepository.findById(eq(18L))).thenReturn(Optional.of(Commons1));
+
+        MvcResult response = mockMvc.perform(get("/api/commons?id=18"))
+                .andExpect(status().isOk()).andReturn();
+
+        verify(commonsRepository, times(1)).findById(eq(18L));
+        String expectedJson = mapper.writeValueAsString(Commons1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    // This common SHOULD NOT be in the repository
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void getCommonsByIdTest_invalid() throws Exception {
+
+        when(commonsRepository.findById(eq(18L))).thenReturn(Optional.empty());
+
+        MvcResult response = mockMvc.perform(get("/api/commons?id=18"))
+                .andExpect(status().is(404)).andReturn();
+
+        verify(commonsRepository, times(1)).findById(eq(18L));
+
+        Map<String, Object> responseMap = responseToJson(response);
+
+        assertEquals(responseMap.get("message"), "Commons with id 18 not found");
+        assertEquals(responseMap.get("type"), "EntityNotFoundException");
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void joinCommonsTest() throws Exception {
+
+        Commons c = Commons.builder()
+                .id(2L)
+                .name("Example Commons")
+                .build();
+
+        UserCommons uc = UserCommons.builder()
+                .userId(1L)
+                .username("Fake user")
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(0)
+                .cowHealth(100)
+                .build();
+
+        UserCommons ucSaved = UserCommons.builder()
+                .id(17L)
+                .userId(1L)
+                .username("Fake user")
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(0)
+                .cowHealth(100)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(uc);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(anyLong(), anyLong())).thenReturn(Optional.empty());
+        when(userCommonsRepository.save(eq(uc))).thenReturn(ucSaved);
+        when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
+
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8").content(requestBody))
+                .andExpect(status().isOk()).andReturn();
+
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
+        verify(userCommonsRepository, times(1)).save(uc);
+
+        String responseString = response.getResponse().getContentAsString();
+        String cAsJson = mapper.writeValueAsString(c);
+
+        assertEquals(responseString, cAsJson);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void already_joined_common_test() throws Exception {
+
+        Commons c = Commons.builder()
+                .id(2L)
+                .name("Example Commons")
+                .build();
+
+        UserCommons uc = UserCommons.builder()
+                .userId(1L)
+                .username("1L")
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(uc);
+
+        // Instead of returning empty, we instead say that it already exists. We
+        // shouldn't create a new entry.
+        when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(uc));
+        when(userCommonsRepository.save(eq(uc))).thenReturn(uc);
+
+        when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
+
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8").content(requestBody))
+                .andExpect(status().isOk()).andReturn();
+
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
+
+        String responseString = response.getResponse().getContentAsString();
+        String cAsJson = mapper.writeValueAsString(c);
+
+        assertEquals(responseString, cAsJson);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void user_commons_exists_but_commons_doesnt_test() throws Exception {
+        UserCommons uc = UserCommons.builder()
+                .userId(1L)
+                .username("1L")
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(uc);
+
+        when(commonsRepository.findById(eq(2L))).thenReturn(Optional.empty());
+
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8").content(requestBody))
+                .andExpect(status().is(404)).andReturn();
+
+        verify(commonsRepository, times(1)).findById(eq(2L));
+
+        Map<String, Object> responseMap = responseToJson(response);
+
+        assertEquals(responseMap.get("message"), "Commons with id 2 not found");
+        assertEquals(responseMap.get("type"), "EntityNotFoundException");
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void join_and_create_userCommons_for_nonexistent_commons() throws Exception {
+        UserCommons uc = UserCommons.builder()
+                .userId(1L)
+                .username("1L")
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
+
+        UserCommons ucSaved = UserCommons.builder()
+                .id(17L)
+                .userId(1L)
+                .username("2L")
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(uc);
+
+        when(commonsRepository.findById(eq(2L))).thenReturn(Optional.empty());
+
+        MvcResult response = mockMvc
+                .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8").content(requestBody))
+                .andExpect(status().is(404)).andReturn();
+
+        verify(commonsRepository, times(1)).findById(eq(2L));
+
+        Map<String, Object> responseMap = responseToJson(response);
+
+        assertEquals(responseMap.get("message"), "Commons with id 2 not found");
+        assertEquals(responseMap.get("type"), "EntityNotFoundException");
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void deleteCommons_test_admin_exists() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons c = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(50.0)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .build();
+
+        when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
+        doNothing().when(commonsRepository).deleteById(2L);
+        doNothing().when(userCommonsRepository).deleteAllByCommonsId(2L);
+
+        MvcResult response = mockMvc.perform(
+                        delete("/api/commons?id=2")
+                                .with(csrf()))
+                .andExpect(status().is(200)).andReturn();
+
+        verify(commonsRepository, times(1)).findById(2L);
+        verify(commonsRepository, times(1)).deleteById(2L);
+        verify(userCommonsRepository, times(1)).deleteAllByCommonsId(2L);
+
+        String responseString = response.getResponse().getContentAsString();
+
+        String expectedString = "{\"message\":\"commons with id 2 deleted\"}";
+
+        assertEquals(expectedString, responseString);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void deleteCommons_test_admin_nonexists() throws Exception {
+
+        when(commonsRepository.findById(eq(2L))).thenReturn(Optional.empty());
+
+        MvcResult response = mockMvc.perform(
+                        delete("/api/commons?id=2")
+                                .with(csrf()))
+                .andExpect(status().is(404)).andReturn();
+        verify(commonsRepository, times(1)).findById(2L);
+
+
+        String expectedString = "{\"message\":\"Commons with id 2 not found\",\"type\":\"EntityNotFoundException\"}";
+
+        Map<String, Object> expectedJson = mapper.readValue(expectedString, new TypeReference<Map<String, Object>>() {
+        });
+        Map<String, Object> jsonResponse = responseToJson(response);
+        assertEquals(expectedJson, jsonResponse);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void deleteUserFromCommonsTest() throws Exception {
+        UserCommons uc = UserCommons.builder()
+                .id(16L)
+                .userId(1L)
+                .username("1L")
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(uc);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(uc));
+
+        MvcResult response = mockMvc
+                .perform(delete("/api/commons/2/users/1").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8").content(requestBody))
+                .andExpect(status().is(204)).andReturn();
+
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
+        verify(userCommonsRepository, times(1)).deleteById(16L);
+
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(responseString, "");
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void deleteUserFromCommonsTest_nonexistent_userCommons() throws Exception {
+        UserCommons uc = UserCommons.builder()
+                .id(16L)
+                .userId(1L)
+                .username("1L")
+                .commonsId(2L)
+                .totalWealth(0)
+                .numOfCows(1)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(uc);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.empty());
+
+        MvcResult response;
+        try {
+            response = mockMvc
+                    .perform(delete("/api/commons/2/users/1").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding("utf-8").content(requestBody))
+                    .andExpect(status().is(204)).andReturn();
+
+            // The way this works is very interesting. The error message is sent as the
+            // value of a nested exception.
+        } catch (Exception e) {
+            assertEquals(e.toString(),
+                    "org.springframework.web.util.NestedServletException: Request processing failed; nested exception is java.lang.Exception: UserCommons with commonsId=2 and userId=1 not found.");
+        }
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void getCommonsPlusTest() throws Exception {
+        List<Commons> expectedCommons = new ArrayList<Commons>();
+        Commons Commons1 = Commons.builder().name("TestCommons1").id(1L).build();
+        expectedCommons.add(Commons1);
+
+        List<CommonsPlus> expectedCommonsPlus = new ArrayList<CommonsPlus>();
+        CommonsPlus CommonsPlus1 = CommonsPlus.builder()
+                .commons(Commons1)
+                .totalCows(50)
+                .totalUsers(20)
+                .build();
+
+        expectedCommonsPlus.add(CommonsPlus1);
+        when(commonsRepository.findAll()).thenReturn(expectedCommons);
+        when(commonsRepository.getNumCows(1L)).thenReturn(Optional.of(50));
+        when(commonsRepository.getNumUsers(1L)).thenReturn(Optional.of(20));
+
+        MvcResult response = mockMvc.perform(get("/api/commons/allplus").contentType("application/json"))
+                .andExpect(status().isOk()).andReturn();
+
+        verify(commonsRepository, times(1)).findAll();
+
+        String responseString = response.getResponse().getContentAsString();
+        List<CommonsPlus> actualCommonsPlus = objectMapper.readValue(responseString,
+                new TypeReference<List<CommonsPlus>>() {
+                });
+        assertEquals(actualCommonsPlus, expectedCommonsPlus);
+    }
 
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -1,11 +1,15 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.when;
-
-import java.util.Arrays;
-import java.util.Optional;
-
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.entities.jobs.Job;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
+import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
+import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategy;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,653 +17,233 @@ import org.mockito.Mock;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import edu.ucsb.cs156.happiercows.entities.jobs.Job;
-import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
-import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
-import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
-import edu.ucsb.cs156.happiercows.repositories.UserRepository;
-import edu.ucsb.cs156.happiercows.entities.Commons;
-import edu.ucsb.cs156.happiercows.entities.UserCommons;
-import edu.ucsb.cs156.happiercows.entities.User;
-
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
 public class UpdateCowHealthJobTests {
-        @Mock
-        CommonsRepository commonsRepository;
-
-        @Mock
-        UserCommonsRepository userCommonsRepository;
-
-        @Mock
-        UserRepository userRepository;
-
-        private User user = User
-                        .builder()
-                        .id(1L)
-                        .fullName("Chris Gaucho")
-                        .email("cgaucho@example.org")
-                        .build();
-
-        @Test
-        void test_log_output_success() throws Exception {
-
-                // Arrange
-
-                Job jobStarted = Job.builder().build();
-                JobContext ctx = new JobContext(null, jobStarted);
-
-                // Act
-                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                                userRepository);
-                updateCowHealthJob.accept(ctx);
-
-                // Assert
-                String expected = """
-                                Updating cow health...
-                                Cow health has been updated!""";
-
-                assertEquals(expected, jobStarted.getLog());
-        }
-
-        @Test
-        void test_updating_to_new_values_if_less_than_carrying_capacity() throws Exception {
-
-                // Arrange
-                Job jobStarted = Job.builder().build();
-                JobContext ctx = new JobContext(null, jobStarted);
-
-                UserCommons origUserCommons = UserCommons
-                                .builder()
-                                .id(1L)
-                                .userId(1L)
-                                .commonsId(1L)
-                                .totalWealth(300)
-                                .numOfCows(1)
-                                .cowHealth(10)
-                                .build();
-
-                Commons testCommons = Commons
-                                .builder()
-                                .name("test commons")
-                                .cowPrice(10)
-                                .milkPrice(2)
-                                .startingBalance(300)
-                                .startingDate(LocalDateTime.now())
-                                .carryingCapacity(100)
-                                .degradationRate(0.01)
-                                .build();
-
-                UserCommons newUserCommons = UserCommons
-                                .builder()
-                                .id(1L)
-                                .userId(1L)
-                                .commonsId(1L)
-                                .totalWealth(300 - testCommons.getCowPrice())
-                                .numOfCows(1)
-                                .cowHealth(10.01)
-                                .build();
-
-                Commons commonsTemp[] = { testCommons };
-                UserCommons userCommonsTemp[] = { origUserCommons };
-                when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
-                when(userCommonsRepository.findByCommonsId(testCommons.getId()))
-                                .thenReturn(Arrays.asList(userCommonsTemp));
-                when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
-                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-
-                // Act
-                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                                userRepository);
-                updateCowHealthJob.accept(ctx);
-
-                // Assert
-
-                String expected = """
-                                Updating cow health...
-                                Commons test commons, degradationRate: 0.01, carryingCapacity: 100
-                                User: Chris Gaucho, numCows: 1, cowHealth: 10.0
-                                 old cow health: 10.0, new cow health: 10.01
-                                Cow health has been updated!""";
-
-                assertEquals(expected, jobStarted.getLog());
-                assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
-        }
-
-        @Test
-        void test_updating_to_new_values_if_greater_than_carrying_capacity() throws Exception {
-
-                // Arrange
-                Job jobStarted = Job.builder().build();
-                JobContext ctx = new JobContext(null, jobStarted);
-
-                UserCommons origUserCommons = UserCommons
-                                .builder()
-                                .id(1L)
-                                .userId(1L)
-                                .commonsId(1L)
-                                .totalWealth(300)
-                                .numOfCows(101)
-                                .cowHealth(100)
-                                .build();
-
-                Commons testCommons = Commons
-                                .builder()
-                                .name("test commons")
-                                .cowPrice(10)
-                                .milkPrice(2)
-                                .startingBalance(300)
-                                .startingDate(LocalDateTime.now())
-                                .carryingCapacity(100)
-                                .degradationRate(0.01)
-                                .build();
-
-                UserCommons newUserCommons = UserCommons
-                                .builder()
-                                .id(1L)
-                                .userId(1L)
-                                .commonsId(1L)
-                                .totalWealth(300 - testCommons.getCowPrice())
-                                .numOfCows(101)
-                                .cowHealth(99.99)
-                                .build();
-
-                Commons commonsTemp[] = { testCommons };
-                UserCommons userCommonsTemp[] = { origUserCommons };
-                when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
-                when(userCommonsRepository.findByCommonsId(testCommons.getId()))
-                                .thenReturn(Arrays.asList(userCommonsTemp));
-                when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(101)));
-                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-
-                // Act
-                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                                userRepository);
-                updateCowHealthJob.accept(ctx);
-
-                // Assert
-
-                String expected = """
-                                Updating cow health...
-                                Commons test commons, degradationRate: 0.01, carryingCapacity: 100
-                                User: Chris Gaucho, numCows: 101, cowHealth: 100.0
-                                 old cow health: 100.0, new cow health: 99.99
-                                Cow health has been updated!""";
-
-                assertEquals(expected, jobStarted.getLog());
-                assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
-        }
-
-        @Test
-        void test_updating_to_new_values_if_equal_to_carrying_capacity() throws Exception {
-
-                // Arrange
-                Job jobStarted = Job.builder().build();
-                JobContext ctx = new JobContext(null, jobStarted);
-
-                UserCommons origUserCommons = UserCommons
-                                .builder()
-                                .id(1L)
-                                .userId(1L)
-                                .commonsId(1L)
-                                .totalWealth(300)
-                                .numOfCows(100)
-                                .cowHealth(50)
-                                .build();
-
-                Commons testCommons = Commons
-                                .builder()
-                                .name("test commons")
-                                .cowPrice(10)
-                                .milkPrice(2)
-                                .startingBalance(300)
-                                .startingDate(LocalDateTime.now())
-                                .carryingCapacity(100)
-                                .degradationRate(0.01)
-                                .build();
-
-                UserCommons newUserCommons = UserCommons
-                                .builder()
-                                .id(1L)
-                                .userId(1L)
-                                .commonsId(1L)
-                                .totalWealth(300 - testCommons.getCowPrice())
-                                .numOfCows(100)
-                                .cowHealth(50.01)
-                                .build();
-
-                Commons commonsTemp[] = { testCommons };
-                UserCommons userCommonsTemp[] = { origUserCommons };
-                when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
-                when(userCommonsRepository.findByCommonsId(testCommons.getId()))
-                                .thenReturn(Arrays.asList(userCommonsTemp));
-                when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(100)));
-                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-
-                // Act
-                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                                userRepository);
-                updateCowHealthJob.accept(ctx);
-
-                // Assert
-
-                String expected = """
-                                Updating cow health...
-                                Commons test commons, degradationRate: 0.01, carryingCapacity: 100
-                                User: Chris Gaucho, numCows: 100, cowHealth: 50.0
-                                 old cow health: 50.0, new cow health: 50.01
-                                Cow health has been updated!""";
-
-                assertEquals(expected, jobStarted.getLog());
-                assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
-        }
-
-        @Test
-        void test_updating_to_new_values_health_lower_than_zero() throws Exception {
-
-                // Arrange
-                Job jobStarted = Job.builder().build();
-                JobContext ctx = new JobContext(null, jobStarted);
-
-                UserCommons origUserCommons = UserCommons
-                                .builder()
-                                .id(1L)
-                                .userId(1L)
-                                .commonsId(1L)
-                                .totalWealth(300)
-                                .numOfCows(150)
-                                .cowHealth(0)
-                                .build();
-
-                Commons testCommons = Commons
-                                .builder()
-                                .name("test commons")
-                                .cowPrice(10)
-                                .milkPrice(2)
-                                .startingBalance(300)
-                                .startingDate(LocalDateTime.now())
-                                .carryingCapacity(100)
-                                .degradationRate(0.01)
-                                .build();
-
-                UserCommons newUserCommons = UserCommons
-                                .builder()
-                                .id(1L)
-                                .userId(1L)
-                                .commonsId(1L)
-                                .totalWealth(300 - testCommons.getCowPrice())
-                                .numOfCows(150)
-                                .cowHealth(0)
-                                .build();
-
-                Commons commonsTemp[] = { testCommons };
-                UserCommons userCommonsTemp[] = { origUserCommons };
-                when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
-                when(userCommonsRepository.findByCommonsId(testCommons.getId()))
-                                .thenReturn(Arrays.asList(userCommonsTemp));
-                when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(150)));
-                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-
-                // Act
-                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                                userRepository);
-                updateCowHealthJob.accept(ctx);
-
-                // Assert
-
-                String expected = """
-                                Updating cow health...
-                                Commons test commons, degradationRate: 0.01, carryingCapacity: 100
-                                User: Chris Gaucho, numCows: 150, cowHealth: 0.0
-                                 old cow health: 0.0, new cow health: 0.0
-                                Cow health has been updated!""";
-
-                assertEquals(expected, jobStarted.getLog());
-                assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
-        }
-
-        @Test
-        void test_updating_to_new_values_health_greater_than_100() throws Exception {
-
-                // Arrange
-                Job jobStarted = Job.builder().build();
-                JobContext ctx = new JobContext(null, jobStarted);
-
-                UserCommons origUserCommons = UserCommons
-                                .builder()
-                                .id(1L)
-                                .userId(1L)
-                                .commonsId(1L)
-                                .totalWealth(300)
-                                .numOfCows(1)
-                                .cowHealth(100)
-                                .build();
-
-                Commons testCommons = Commons
-                                .builder()
-                                .name("test commons")
-                                .cowPrice(10)
-                                .milkPrice(2)
-                                .startingBalance(300)
-                                .startingDate(LocalDateTime.now())
-                                .carryingCapacity(100)
-                                .degradationRate(0.01)
-                                .build();
-
-                UserCommons newUserCommons = UserCommons
-                                .builder()
-                                .id(1L)
-                                .userId(1L)
-                                .commonsId(1L)
-                                .totalWealth(300 - testCommons.getCowPrice())
-                                .numOfCows(1)
-                                .cowHealth(100)
-                                .build();
-
-                Commons commonsTemp[] = { testCommons };
-                UserCommons userCommonsTemp[] = { origUserCommons };
-                when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
-                when(userCommonsRepository.findByCommonsId(testCommons.getId()))
-                                .thenReturn(Arrays.asList(userCommonsTemp));
-                when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
-                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-
-                // Act
-                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                                userRepository);
-                updateCowHealthJob.accept(ctx);
-
-                // Assert
-
-                String expected = """
-                                Updating cow health...
-                                Commons test commons, degradationRate: 0.01, carryingCapacity: 100
-                                User: Chris Gaucho, numCows: 1, cowHealth: 100.0
-                                 old cow health: 100.0, new cow health: 100.0
-                                Cow health has been updated!""";
-
-                assertEquals(expected, jobStarted.getLog());
-                assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
-        }
-
-        @Test
-        void test_updating_to_new_values_for_multiple() throws Exception {
-
-                // Arrange
-                Job jobStarted = Job.builder().build();
-                JobContext ctx = new JobContext(null, jobStarted);
-
-                UserCommons origUserCommons1 = UserCommons
-                                .builder()
-                                .id(1L)
-                                .userId(1L)
-                                .commonsId(1L)
-                                .totalWealth(300)
-                                .numOfCows(5)
-                                .cowHealth(50)
-                                .build();
-
-                UserCommons origUserCommons2 = UserCommons
-                                .builder()
-                                .id(1L)
-                                .userId(1L)
-                                .commonsId(1L)
-                                .totalWealth(300)
-                                .numOfCows(5)
-                                .cowHealth(50)
-                                .build();
-
-                UserCommons origUserCommons3 = UserCommons
-                                .builder()
-                                .id(1L)
-                                .userId(1L)
-                                .commonsId(1L)
-                                .totalWealth(300)
-                                .numOfCows(5)
-                                .cowHealth(50)
-                                .build();
-
-                Commons testCommons = Commons
-                                .builder()
-                                .name("test commons")
-                                .cowPrice(10)
-                                .milkPrice(2)
-                                .startingBalance(300)
-                                .startingDate(LocalDateTime.now())
-                                .carryingCapacity(10)
-                                .degradationRate(0.01)
-                                .build();
-
-                UserCommons newUserCommons = UserCommons
-                                .builder()
-                                .id(1L)
-                                .userId(1L)
-                                .commonsId(1L)
-                                .totalWealth(300 - testCommons.getCowPrice())
-                                .numOfCows(5)
-                                .cowHealth(50.01)
-                                .build();
-
-                Commons commonsTemp[] = { testCommons };
-                UserCommons userCommonsTemp[] = { origUserCommons1, origUserCommons2, origUserCommons3 };
-                when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
-                when(userCommonsRepository.findByCommonsId(testCommons.getId()))
-                                .thenReturn(Arrays.asList(userCommonsTemp));
-                when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
-                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-
-                // Act
-                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                                userRepository);
-                updateCowHealthJob.accept(ctx);
-
-                // Assert
-
-                String expected = """
-                                Updating cow health...
-                                Commons test commons, degradationRate: 0.01, carryingCapacity: 10
-                                User: Chris Gaucho, numCows: 5, cowHealth: 50.0
-                                 old cow health: 50.0, new cow health: 50.01
-                                User: Chris Gaucho, numCows: 5, cowHealth: 50.0
-                                 old cow health: 50.0, new cow health: 50.01
-                                User: Chris Gaucho, numCows: 5, cowHealth: 50.0
-                                 old cow health: 50.0, new cow health: 50.01
-                                Cow health has been updated!""";
-
-                assertEquals(expected, jobStarted.getLog());
-                assertEquals(origUserCommons1.getCowHealth(), newUserCommons.getCowHealth());
-                assertEquals(origUserCommons2.getCowHealth(), newUserCommons.getCowHealth());
-                assertEquals(origUserCommons3.getCowHealth(), newUserCommons.getCowHealth());
-        }
-
-        @Test
-        void test_throws_exception_when_get_num_cows_fails() throws Exception {
-
-                // Arrange
-                Job jobStarted = Job.builder().build();
-                JobContext ctx = new JobContext(null, jobStarted);
-
-                UserCommons origUserCommons = UserCommons
-                                .builder()
-                                .id(1L)
-                                .userId(1L)
-                                .commonsId(1L)
-                                .totalWealth(300)
-                                .numOfCows(1)
-                                .cowHealth(10)
-                                .build();
-
-                Commons testCommons = Commons
-                                .builder()
-                                .id(117L)
-                                .name("test commons")
-                                .cowPrice(10)
-                                .milkPrice(2)
-                                .startingBalance(300)
-                                .startingDate(LocalDateTime.now())
-                                .carryingCapacity(100)
-                                .degradationRate(0.01)
-                                .build();
-
-                Commons commonsTemp[] = { testCommons };
-                UserCommons userCommonsTemp[] = { origUserCommons };
-                when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
-                when(userCommonsRepository.findByCommonsId(testCommons.getId()))
-                                .thenReturn(Arrays.asList(userCommonsTemp));
-                when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.empty());
-                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-
-                // Act
-                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                                userRepository);
-
-                RuntimeException thrown = Assertions.assertThrows(RuntimeException.class, () -> {
-                        // Code under test
-                        updateCowHealthJob.accept(ctx);
-                });
-
-                Assertions.assertEquals("Error calling getNumCows(117)", thrown.getMessage());
-
-        }
-
-        @Test
-        void test_throws_exception_when_getting_user_fails() throws Exception {
-
-                // Arrange
-                Job jobStarted = Job.builder().build();
-                JobContext ctx = new JobContext(null, jobStarted);
-
-                UserCommons origUserCommons = UserCommons
-                                .builder()
-                                .id(1L)
-                                .userId(321L)
-                                .commonsId(1L)
-                                .totalWealth(300)
-                                .numOfCows(1)
-                                .cowHealth(10)
-                                .build();
-
-                Commons testCommons = Commons
-                                .builder()
-                                .id(117L)
-                                .name("test commons")
-                                .cowPrice(10)
-                                .milkPrice(2)
-                                .startingBalance(300)
-                                .startingDate(LocalDateTime.now())
-                                .carryingCapacity(100)
-                                .degradationRate(0.01)
-                                .build();
-
-                Commons commonsTemp[] = { testCommons };
-                UserCommons userCommonsTemp[] = { origUserCommons };
-                when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
-                when(userCommonsRepository.findByCommonsId(testCommons.getId()))
-                                .thenReturn(Arrays.asList(userCommonsTemp));
-                when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(10));
-                when(userRepository.findById(321L)).thenReturn(Optional.empty());
-
-                // Act
-                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                                userRepository);
-
-                RuntimeException thrown = Assertions.assertThrows(RuntimeException.class, () -> {
-                        // Code under test
-                        updateCowHealthJob.accept(ctx);
-                });
-
-                Assertions.assertEquals("Error calling userRepository.findById(321)", thrown.getMessage());
-
-        }
-
-        @Test
-        void test_calculateNewCowHealth__numCows_lt_carryingCapacity_old_health_at_100__no_change() {
-             
-                // arrange
-              
-                double oldCowHealth = 100.0;
-                int numCows = 50;
-                int totalCows = 80;
-                int carryingCapacity = 100;
-                double degradationRate = 3.0;
-
-                // act
-
-                double newCowHealth = UpdateCowHealthJob.calculateNewCowHealth(oldCowHealth, numCows, totalCows,
-                                carryingCapacity, degradationRate);
-
-                // assert
-
-                assertEquals(100.0, newCowHealth);
-
-        }
-
-        @Test
-        void test_calculateNewCowHealth__numCows_lt_carryingCapacity_old_health_at_80__goes_up() {
-             
-                // arrange
-              
-                double oldCowHealth = 80.123;
-                int numCows = 50;
-                int totalCows = 80;
-                int carryingCapacity = 100;
-                double degradationRate = 3.456;
-
-                // act
-
-                double newCowHealth = UpdateCowHealthJob.calculateNewCowHealth(oldCowHealth, numCows, totalCows,
-                                carryingCapacity, degradationRate);
-
-                // assert
-
-                assertEquals(83.579, newCowHealth, 0.0001);
-
-        }
-
-        @Test
-        void test_calculateNewCowHealth__numCows_one_over_carryingCapacity_old_health_at_80__goes_down_by_degradation_rate() {
-             
-                // arrange
-              
-                double oldCowHealth = 83.579;
-                int numCows = 50;
-                int totalCows = 101;
-                int carryingCapacity = 100;
-                double degradationRate = 3.456;
-
-                // act
-
-                double newCowHealth = UpdateCowHealthJob.calculateNewCowHealth(oldCowHealth, numCows, totalCows,
-                                carryingCapacity, degradationRate);
-
-                // assert
-
-                assertEquals(80.123, newCowHealth, 0.0001);
-
-        }
-
-        @Test
-        void test_calculateNewCowHealth__numCows_ten_over_carryingCapacity_old_health_at_80__goes_down_by_degradation_rate_times_10() {
-             
-                // arrange
-              
-                double oldCowHealth = 100.0;
-                int numCows = 50;
-                int totalCows = 110;
-                int carryingCapacity = 100;
-                double degradationRate = 1.234;
-
-                // act
-
-                double newCowHealth = UpdateCowHealthJob.calculateNewCowHealth(oldCowHealth, numCows, totalCows,
-                                carryingCapacity, degradationRate);
-
-                // assert
-
-                assertEquals((100.0 - 12.34), newCowHealth, 0.0001);
-
-        }
-
+    @Mock
+    CommonsRepository commonsRepository;
+
+    @Mock
+    UserCommonsRepository userCommonsRepository;
+
+    @Mock
+    UserRepository userRepository;
+
+    private final User user = User
+            .builder()
+            .id(1L)
+            .fullName("Chris Gaucho")
+            .email("cgaucho@example.org")
+            .build();
+
+    private final UserCommons userCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300)
+            .numOfCows(1)
+            .cowHealth(10.0)
+            .build();
+
+    private final Commons commons = Commons
+            .builder()
+            .name("test commons")
+            .cowPrice(10)
+            .milkPrice(2)
+            .startingBalance(300)
+            .startingDate(LocalDateTime.now())
+            .carryingCapacity(100)
+            .degradationRate(1)
+            .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Noop)
+            .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Noop)
+            .build();
+
+    private final Job job = Job.builder().build();
+    private final JobContext ctx = new JobContext(null, job);
+
+    private void runUpdateCowHealthJob() throws Exception {
+        var updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository, userRepository);
+        updateCowHealthJob.accept(ctx);
+    }
+
+    @Test
+    void test_log_output_with_no_commons() throws Exception {
+        runUpdateCowHealthJob();
+
+        String expected = """
+                Updating cow health...
+                Cow health has been updated!""";
+        assertEquals(expected, job.getLog());
+    }
+
+    private void setupUpdateCowHealthTestOnCommons(int totalCows) {
+        when(commonsRepository.findAll()).thenReturn(List.of(commons));
+        when(userCommonsRepository.findByCommonsId(commons.getId())).thenReturn(List.of(userCommons));
+        when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(totalCows));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+    }
+
+    @Test
+    void test_uses_above_capacity_update_strategy() throws Exception {
+        commons.setAboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant);
+        double expectedNewHealth = 9.0;
+
+        setupUpdateCowHealthTestOnCommons(101);
+        runUpdateCowHealthJob();
+
+        assertEquals(expectedNewHealth, userCommons.getCowHealth());
+
+        String expected = """
+                Updating cow health...
+                Commons test commons, degradationRate: 1.0, carryingCapacity: 100
+                User: Chris Gaucho, numCows: 1, cowHealth: 10.0
+                 old cow health: 10.0, new cow health: 9.0
+                Cow health has been updated!""";
+        assertEquals(expected, job.getLog());
+    }
+
+    @Test
+    void test_uses_below_capacity_update_strategy() throws Exception {
+        commons.setBelowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant);
+        double expectedNewHealth = 11.0;
+
+        setupUpdateCowHealthTestOnCommons(99);
+        runUpdateCowHealthJob();
+
+        assertEquals(expectedNewHealth, userCommons.getCowHealth());
+
+        String expected = """
+                Updating cow health...
+                Commons test commons, degradationRate: 1.0, carryingCapacity: 100
+                User: Chris Gaucho, numCows: 1, cowHealth: 10.0
+                 old cow health: 10.0, new cow health: 11.0
+                Cow health has been updated!""";
+        assertEquals(expected, job.getLog());
+    }
+
+
+    @Test
+    void test_uses_below_capacity_update_strategy_if_equal_to_carrying_capacity() throws Exception {
+        commons.setBelowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant);
+        double expectedNewHealth = 11.0;
+
+        setupUpdateCowHealthTestOnCommons(commons.getCarryingCapacity());
+        runUpdateCowHealthJob();
+
+        assertEquals(expectedNewHealth, userCommons.getCowHealth());
+        String expected = """
+                Updating cow health...
+                Commons test commons, degradationRate: 1.0, carryingCapacity: 100
+                User: Chris Gaucho, numCows: 1, cowHealth: 10.0
+                 old cow health: 10.0, new cow health: 11.0
+                Cow health has been updated!""";
+        assertEquals(expected, job.getLog());
+    }
+
+    @Test
+    void test_cow_health_minimum_is_0() throws Exception {
+        var mockStrategy = mock(CowHealthUpdateStrategy.class);
+        when(mockStrategy.calculateNewCowHealth(any(), any(), anyInt())).thenReturn(-1.0);
+        var newHealth = UpdateCowHealthJob.calculateNewCowHealthUsingStrategy(
+                mockStrategy,
+                commons,
+                userCommons,
+                1
+        );
+        assertEquals(0.0, newHealth);
+    }
+
+    @Test
+    void test_cow_health_maximum_is_100() throws Exception {
+        var mockStrategy = mock(CowHealthUpdateStrategy.class);
+        when(mockStrategy.calculateNewCowHealth(any(), any(), anyInt())).thenReturn(101.0);
+        var newHealth = UpdateCowHealthJob.calculateNewCowHealthUsingStrategy(
+                mockStrategy,
+                commons,
+                userCommons,
+                1
+        );
+        assertEquals(100.0, newHealth);
+    }
+
+    @Test
+    void test_updating_values_for_multiple_users() throws Exception {
+        var userCommons1 = userCommons;
+        var userCommons2 = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(6)
+                .cowHealth(20)
+                .build();
+        commons.setBelowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear);
+
+        when(commonsRepository.findAll()).thenReturn(List.of(commons));
+        when(userCommonsRepository.findByCommonsId(commons.getId())).thenReturn(List.of(userCommons1, userCommons2));
+        when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(99));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        runUpdateCowHealthJob();
+
+
+        String expected = """
+                Updating cow health...
+                Commons test commons, degradationRate: 1.0, carryingCapacity: 100
+                User: Chris Gaucho, numCows: 1, cowHealth: 10.0
+                 old cow health: 10.0, new cow health: 11.0
+                User: Chris Gaucho, numCows: 6, cowHealth: 20.0
+                 old cow health: 20.0, new cow health: 21.0
+                Cow health has been updated!""";
+
+        assertEquals(expected, job.getLog());
+
+        assertEquals(11.0, userCommons1.getCowHealth());
+        assertEquals(21.0, userCommons2.getCowHealth());
+    }
+
+    @Test
+    void test_throws_exception_when_get_num_cows_fails() {
+        setupUpdateCowHealthTestOnCommons(100);
+        commons.setId(117);
+        when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.empty());
+
+        var updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                userRepository);
+
+        var thrown = Assertions.assertThrows(RuntimeException.class, () -> {
+            updateCowHealthJob.accept(ctx);
+        });
+
+        Assertions.assertEquals("Error calling getNumCows(117)", thrown.getMessage());
+    }
+
+    @Test
+    void test_throws_exception_when_getting_user_fails() {
+        user.setId(321);
+        userCommons.setUserId(user.getId());
+        setupUpdateCowHealthTestOnCommons(100);
+        when(userRepository.findById(user.getId())).thenReturn(Optional.empty());
+
+        var updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                userRepository);
+
+        var thrown = Assertions.assertThrows(RuntimeException.class, () -> {
+            updateCowHealthJob.accept(ctx);
+        });
+
+        Assertions.assertEquals("Error calling userRepository.findById(321)", thrown.getMessage());
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/models/HealthUpdateStrategyListTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/models/HealthUpdateStrategyListTests.java
@@ -1,0 +1,30 @@
+package edu.ucsb.cs156.happiercows.models;
+
+import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HealthUpdateStrategyListTests {
+
+    HealthUpdateStrategyList value = HealthUpdateStrategyList.create();
+
+    @Test
+    void createdValueHasDefaults() {
+        assertEquals(CowHealthUpdateStrategies.DEFAULT_ABOVE_CAPACITY.name(), value.getDefaultAboveCapacity());
+        assertEquals(CowHealthUpdateStrategies.DEFAULT_BELOW_CAPACITY.name(), value.getDefaultBelowCapacity());
+    }
+
+    @Test
+    void strategiesListMatchesEnumValues() {
+        for (int i = 0; i < CowHealthUpdateStrategies.values().length; i++) {
+            var listValue = value.getStrategies().get(i);
+            var enumValue = CowHealthUpdateStrategies.values()[i];
+
+            assertEquals(enumValue.name(), listValue.getName());
+            assertEquals(enumValue.getDescription(), listValue.getDescription());
+            assertEquals(enumValue.getDisplayName(), listValue.getDisplayName());
+        }
+
+    }
+}


### PR DESCRIPTION
Depends on #21 

In this PR, we modify the backend to use different cow health update strategies.
- the `Commons` entity now stores different strategies for updating both when above and below capacity
- API endpoints for creating/editing commons is modified appropriately
- If the strategy is not specified, it sets the strategy to defaults matching the old behavior; this is so the old frontend still works.
- `UpdateCowHealthJob` is modified to use the strategies.
- I cleaned up `UpdateCowHealthJobTests`, so instead of being 11x longer than the file it tests... it's now 5x longer.


Closes #15 

Unrelated comments:
- Can we choose some number of spaces for indentation and use it consistently? I've seen 2, 4, and now 8 spaces...

