### PR TITLE
Adding link and modifying SystemInfo api with relevant tests

### DIFF
--- a/frontend/src/fixtures/systemInfoFixtures.js
+++ b/frontend/src/fixtures/systemInfoFixtures.js
@@ -3,7 +3,7 @@ const systemInfoFixtures = {
     {
         "springH2ConsoleEnabled": true,
         "showSwaggerUILink": true,
-        "sourceRepo": "https://github.com/ucsb-cs156-f22/f22-5pm-happycows"
+        "sourceRepo": "https://github.com/ucsb-cs156/proj-happycows"
     },
     showingNeither:
     {

--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -8,7 +8,6 @@ export default function Footer({systemInfo}) {
           HappierCows is a project of <a href="https://devries.chem.ucsb.edu/mattanjah-de-vries">Mattanjah de Vries</a>, 
           Distinguished Professor of Chemistry at UC Santa Barbara. 
           The open source code is<a data-testid="github-href" href={systemInfo?.sourceRepo}> available on GitHub</a>. 
-          <a href="https://github.com/ucsb-cs156/proj-happycows">HELP</a>
         </p>
         
       </Container>

--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -7,7 +7,7 @@ export default function Footer({systemInfo}) {
         <p data-testid="footer-content">
           HappierCows is a project of <a href="https://devries.chem.ucsb.edu/mattanjah-de-vries">Mattanjah de Vries</a>, 
           Distinguished Professor of Chemistry at UC Santa Barbara. 
-          The open source code is<a data-testid="github-href" href={systemInfo?.sourceRepo}> available on GitHub</a>. 
+          The open source code is <a data-testid="github-href" href={systemInfo?.sourceRepo}>available on GitHub</a>. 
         </p>
         
       </Container>

--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -7,7 +7,8 @@ export default function Footer({systemInfo}) {
         <p data-testid="footer-content">
           HappierCows is a project of <a href="https://devries.chem.ucsb.edu/mattanjah-de-vries">Mattanjah de Vries</a>, 
           Distinguished Professor of Chemistry at UC Santa Barbara. 
-          The open source code is available on <a data-testid="github-href" href={systemInfo?.sourceRepo}>GitHub</a>. 
+          The open source code is<a data-testid="github-href" href={systemInfo?.sourceRepo}> available on GitHub</a>. 
+          <a href="https://github.com/ucsb-cs156/proj-happycows">HELP</a>
         </p>
         
       </Container>

--- a/frontend/src/main/layouts/BasicLayout/BasicLayout.js
+++ b/frontend/src/main/layouts/BasicLayout/BasicLayout.js
@@ -10,7 +10,6 @@ export default function BasicLayout({ children }) {
   const { data: systemInfo } = useSystemInfo();
 
   const doLogout = useLogout().mutate;
-
   return (
     <div className="d-flex flex-column min-vh-100">
       <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogout={doLogout} />

--- a/frontend/src/main/layouts/BasicLayout/BasicLayout.js
+++ b/frontend/src/main/layouts/BasicLayout/BasicLayout.js
@@ -10,6 +10,7 @@ export default function BasicLayout({ children }) {
   const { data: systemInfo } = useSystemInfo();
 
   const doLogout = useLogout().mutate;
+  
   return (
     <div className="d-flex flex-column min-vh-100">
       <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogout={doLogout} />

--- a/frontend/src/main/utils/systemInfo.js
+++ b/frontend/src/main/utils/systemInfo.js
@@ -6,7 +6,7 @@ export function useSystemInfo() {
   return useQuery("systemInfo", async () => {
     try {
       const response = await axios.get("/api/systemInfo");
-      document.write(response?.springH2ConsoleEnabled)
+      //document.write(response?.springH2ConsoleEnabled)
       return response.data;
     } catch (e) {
       console.error("Error invoking axios.get: ", e);

--- a/frontend/src/main/utils/systemInfo.js
+++ b/frontend/src/main/utils/systemInfo.js
@@ -6,6 +6,7 @@ export function useSystemInfo() {
   return useQuery("systemInfo", async () => {
     try {
       const response = await axios.get("/api/systemInfo");
+      document.write(response?.springH2ConsoleEnabled)
       return response.data;
     } catch (e) {
       console.error("Error invoking axios.get: ", e);

--- a/frontend/src/main/utils/systemInfo.js
+++ b/frontend/src/main/utils/systemInfo.js
@@ -6,7 +6,6 @@ export function useSystemInfo() {
   return useQuery("systemInfo", async () => {
     try {
       const response = await axios.get("/api/systemInfo");
-      //document.write(response?.springH2ConsoleEnabled)
       return response.data;
     } catch (e) {
       console.error("Error invoking axios.get: ", e);

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -14,7 +14,7 @@ describe("Footer tests", () => {
         expect(text.textContent).toEqual('HappierCows is a project of Mattanjah de Vries, Distinguished Professor of Chemistry at UC Santa Barbara. The open source code is available on GitHub.');
     
         const href = screen.getByTestId("github-href");
-        // console.log(href.href);
+        console.log(href.href);
         expect(href).toHaveAttribute("href", "https://github.com/ucsb-cs156/proj-happycows");
     });
 

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -14,7 +14,7 @@ describe("Footer tests", () => {
         expect(text.textContent).toEqual('HappierCows is a project of Mattanjah de Vries, Distinguished Professor of Chemistry at UC Santa Barbara. The open source code is available on GitHub.');
     
         const href = screen.getByTestId("github-href");
-        console.log(href.href);
+        //console.log(href.href);
         expect(href).toHaveAttribute("href", "https://github.com/ucsb-cs156/proj-happycows");
     });
 
@@ -29,7 +29,7 @@ describe("Footer tests", () => {
         // expect(text.textContent).toEqual('HappierCows is a project of Mattanjah de Vries, Distinguished Professor of Chemistry at UC Santa Barbara. The open source code is available on GitHub.');
     
         const href = screen.getByTestId("github-href");
-        console.log(href.href);
+        //console.log(href.href);
         expect(href.href).toBe("");
         // expect(href).toHaveAttribute("href", undefined);
     });

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -14,7 +14,6 @@ describe("Footer tests", () => {
         expect(text.textContent).toEqual('HappierCows is a project of Mattanjah de Vries, Distinguished Professor of Chemistry at UC Santa Barbara. The open source code is available on GitHub.');
     
         const href = screen.getByTestId("github-href");
-        //console.log(href.href);
         expect(href).toHaveAttribute("href", "https://github.com/ucsb-cs156/proj-happycows");
     });
 
@@ -25,12 +24,8 @@ describe("Footer tests", () => {
 
         const text = screen.getByTestId("footer-content");
         expect(text).toBeInTheDocument();
-        // expect(typeof(text.textContent)).toBe('string');
-        // expect(text.textContent).toEqual('HappierCows is a project of Mattanjah de Vries, Distinguished Professor of Chemistry at UC Santa Barbara. The open source code is available on GitHub.');
-    
+            
         const href = screen.getByTestId("github-href");
-        //console.log(href.href);
         expect(href.href).toBe("");
-        // expect(href).toHaveAttribute("href", undefined);
     });
 });

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -15,7 +15,7 @@ describe("Footer tests", () => {
     
         const href = screen.getByTestId("github-href");
         // console.log(href.href);
-        expect(href).toHaveAttribute("href", "https://github.com/ucsb-cs156-f22/f22-5pm-happycows");
+        expect(href).toHaveAttribute("href", "https://github.com/ucsb-cs156/proj-happycows");
     });
 
     test("renders correctly when systemInfo.showingNeither", async () => {

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/SystemInfoController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/SystemInfoController.java
@@ -20,7 +20,6 @@ public class SystemInfoController extends ApiController {
     private SystemInfoService systemInfoService;
 
     @ApiOperation(value = "Get global information about the application")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("")
     public SystemInfo getSystemInfo() {
         return systemInfoService.getSystemInfo();

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/SystemInfoController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/SystemInfoController.java
@@ -20,6 +20,7 @@ public class SystemInfoController extends ApiController {
     private SystemInfoService systemInfoService;
 
     @ApiOperation(value = "Get global information about the application")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("")
     public SystemInfo getSystemInfo() {
         return systemInfoService.getSystemInfo();

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImpl.java
@@ -22,7 +22,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
-  @Value("${app.sourceRepo}")
+  @Value("${app.sourceRepo:test}")
   String sourceRepo;
 
   public SystemInfo getSystemInfo() {

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImpl.java
@@ -22,7 +22,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
-  @Value("${app.sourceRepo:test}")
+  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-happycows}")
   String sourceRepo;
 
   public SystemInfo getSystemInfo() {

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImpl.java
@@ -22,8 +22,8 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
-  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-happycows}")
-  String sourceRepo;
+  @Value("${app.sourceRepo}")
+  private String sourceRepo = "https://github.com/ucsb-cs156/proj-happycows";
 
   public SystemInfo getSystemInfo() {
     SystemInfo si = SystemInfo.builder()

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -6,7 +6,7 @@ spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
 spring.h2.console.enabled=true
 app.showSwaggerUILink=true
-app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-courses}}
+app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-happycows}}
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.datasource.initialization-mode=always

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/SystemInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/SystemInfoControllerTests.java
@@ -29,16 +29,54 @@ public class SystemInfoControllerTests extends ControllerTestCase {
 
   @Test
   public void systemInfo__logged_out() throws Exception {
-    mockMvc.perform(get("/api/systemInfo"))
-        .andExpect(status().is(403));
+
+
+    // arrange
+
+    SystemInfo systemInfo = SystemInfo
+        .builder()
+        .showSwaggerUILink(true)
+        .springH2ConsoleEnabled(true)
+        .sourceRepo("https://github.com/ucsb-cs156/proj-happycows")
+        .build();
+    when(mockSystemInfoService.getSystemInfo()).thenReturn(systemInfo);
+    String expectedJson = mapper.writeValueAsString(systemInfo);
+
+    // act
+    MvcResult response = mockMvc.perform(get("/api/systemInfo"))
+        .andExpect(status().isOk()).andReturn();
+
+    // assert
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
   }
+
 
   @WithMockUser(roles = { "USER" })
   @Test
   public void systemInfo__user_logged_in() throws Exception {
-    mockMvc.perform(get("/api/systemInfo"))
-        .andExpect(status().is(403));
+
+
+    // arrange
+
+    SystemInfo systemInfo = SystemInfo
+        .builder()
+        .showSwaggerUILink(true)
+        .springH2ConsoleEnabled(true)
+        .sourceRepo("https://github.com/ucsb-cs156/proj-happycows")
+        .build();
+    when(mockSystemInfoService.getSystemInfo()).thenReturn(systemInfo);
+    String expectedJson = mapper.writeValueAsString(systemInfo);
+
+    // act
+    MvcResult response = mockMvc.perform(get("/api/systemInfo"))
+        .andExpect(status().isOk()).andReturn();
+
+    // assert
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
   }
+
 
   @WithMockUser(roles = { "ADMIN" })
   @Test
@@ -51,7 +89,7 @@ public class SystemInfoControllerTests extends ControllerTestCase {
         .builder()
         .showSwaggerUILink(true)
         .springH2ConsoleEnabled(true)
-        .sourceRepo("https://github.com/ucsb-cs156/proj-courses")
+        .sourceRepo("https://github.com/ucsb-cs156/proj-happycows")
         .build();
     when(mockSystemInfoService.getSystemInfo()).thenReturn(systemInfo);
     String expectedJson = mapper.writeValueAsString(systemInfo);

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImplTests.java
@@ -33,7 +33,7 @@ class SystemInfoServiceImplTests  {
     SystemInfo si = systemInfoService.getSystemInfo();
     assertTrue(si.getSpringH2ConsoleEnabled());
     assertTrue(si.getShowSwaggerUILink());
-    assertEquals("https://github.com/ucsb-cs156/proj-courses", si.getSourceRepo());
+    assertEquals("https://github.com/ucsb-cs156/proj-happycows", si.getSourceRepo());
   }
 
 }


### PR DESCRIPTION
In this PR, I added/changed the link within the SystemInfo api.

As also requested by pconrad, I removed the admin restriction for the SystemInfo api as well to accomodate the github link showing up on the home page even for those who aren't logged in/don't have admin role.
 
Relevant tests for SystemInfo and Footer have also been updated.