### PR TITLE
Display user information in table on profile page

### DIFF
--- a/frontend/src/main/components/UserProfileTable.js
+++ b/frontend/src/main/components/UserProfileTable.js
@@ -1,0 +1,57 @@
+import React from "react";
+import { Table } from "react-bootstrap";
+
+export default function UserProfileTable({ user }) {
+    return (
+        <Table striped bordered hover>
+            <thread>
+                <tr>
+                    <th>First Name</th>
+                    <td>{user.givenName}</td>
+                </tr>
+                <tr>
+                    <th>Last Name</th>
+                    <td>{user.familyName}</td>
+                </tr>
+                <tr>
+                    <th>Email</th>
+                    <td>{user.email}</td>
+                </tr>
+                <tr>
+                    <th>Joined Commons</th>
+                    <td>{commonsString(user.commons)}</td>
+                </tr>
+                <tr>
+                    <th>User ID</th>
+                    <td>{user.id}</td>
+                </tr>
+                <tr>
+                    <th>Admin</th>
+                    <td>{String(user.admin)}</td>
+                </tr>
+                <tr>
+                    <th>Hosted Domain</th>
+                    <td>{user.hostedDomain}</td>
+                </tr>
+                <tr>
+                    <th>Locale</th>
+                    <td>{user.locale}</td>
+                </tr>
+            </thread>
+        </Table>
+    );
+}
+
+function commonsString(commons) {
+    if(commons === undefined)
+        return "";
+    
+    var result = "";
+
+    for (var i = 0; i < commons.length; i++) {
+        result += commons[i].name + ", ";
+    }
+    result = result.substring(0, result.length - 2);
+
+    return result;
+}

--- a/frontend/src/main/components/UserProfileTable.js
+++ b/frontend/src/main/components/UserProfileTable.js
@@ -43,15 +43,14 @@ export default function UserProfileTable({ user }) {
 }
 
 function commonsString(commons) {
-    if(commons === undefined)
-        return "";
-    
     var result = "";
 
-    for (var i = 0; i < commons.length; i++) {
-        result += commons[i].name + ", ";
+    if (commons !== undefined) {
+        for (var i = 0; i < commons.length; i++) {
+            result += commons[i].name + ", ";
+        }
+        result = result.substring(0, result.length - 2);
     }
-    result = result.substring(0, result.length - 2);
 
     return result;
 }

--- a/frontend/src/main/pages/ProfilePage.js
+++ b/frontend/src/main/pages/ProfilePage.js
@@ -3,8 +3,8 @@ import { Row, Col } from "react-bootstrap";
 import RoleBadge from "main/components/Profile/RoleBadge";
 import { useCurrentUser } from "main/utils/currentUser";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UserProfileTable from "main/components/UserProfileTable";
 
-import ReactJson from "react-json-view";
 const ProfilePage = () => {
 
     const { data: currentUser } = useCurrentUser();
@@ -35,7 +35,9 @@ const ProfilePage = () => {
                 </Col>
             </Row>
             <Row className="text-left">
-                <ReactJson src={currentUser.root} />
+                <Col className="align-items-center text-center">
+                    <UserProfileTable user={currentUser.root.user} />
+                </Col>
             </Row>
         </BasicLayout>
     );

--- a/frontend/src/stories/components/UserProfileTable.stories.js
+++ b/frontend/src/stories/components/UserProfileTable.stories.js
@@ -1,0 +1,19 @@
+
+import React from 'react';
+import UserProfileTable from 'main/components/UserProfileTable';
+import { apiCurrentUserFixtures } from 'fixtures/currentUserFixtures';
+
+export default {
+    title: 'components/UserProfileTable',
+    component: UserProfileTable
+};
+
+const Template = (args) => {
+    return (
+        <UserProfileTable {...args} />
+    )
+};
+
+export const Sample = Template.bind({});
+
+Sample.args =  {user: apiCurrentUserFixtures.adminUser.user};

--- a/frontend/src/tests/components/UserProfileTable.test.js
+++ b/frontend/src/tests/components/UserProfileTable.test.js
@@ -1,0 +1,38 @@
+import UserProfileTable from "main/components/UserProfileTable";
+import { render, screen } from "@testing-library/react";
+
+describe("UserProfileTable tests", () => {
+    test("renders an empty table without crashing", () => {
+        render(
+            <UserProfileTable user={{}} />
+        );
+
+        expect(screen.queryByText("Stryker was here!")).not.toBeInTheDocument();
+    });
+    test("renders a table with user info", () => {
+        const user = {
+            givenName: "Joe",
+            familyName: "Biden",
+            email: "joebiden@whitehouse.gov",
+            commons: [{name: "Commons 1"}, {name: "Commons 2"}],
+            id: 1,
+            admin: true,
+            hostedDomain: "whitehouse.gov",
+            locale: "en"}
+
+        render(
+            <UserProfileTable user={user} />
+        );
+        
+        expect(screen.getByText("Joe")).toBeInTheDocument();
+        expect(screen.getByText("Biden")).toBeInTheDocument();
+        expect(screen.getByText("joebiden@whitehouse.gov")).toBeInTheDocument();
+        expect(screen.getByText("Commons 1, Commons 2")).toBeInTheDocument();
+        expect(screen.getByText("1")).toBeInTheDocument();
+        expect(screen.getByText("true")).toBeInTheDocument();
+        expect(screen.getByText("whitehouse.gov")).toBeInTheDocument();
+        expect(screen.getByText("en")).toBeInTheDocument();
+        expect(screen.queryByText("Stryker was here!")).not.toBeInTheDocument();
+
+    });
+});

--- a/frontend/src/tests/pages/ProfilePage.test.js
+++ b/frontend/src/tests/pages/ProfilePage.test.js
@@ -29,7 +29,7 @@ describe("ProfilePage tests", () => {
         );
 
         expect(await screen.findByText("Phillip Conrad")).toBeInTheDocument();
-        expect(screen.getByText("pconrad.cis@gmail.com")).toBeInTheDocument();
+        expect(screen.getAllByText("pconrad.cis@gmail.com")[1]).toBeInTheDocument();
     });
 
     test("renders correctly for admin user from UCSB", async () => {
@@ -44,7 +44,7 @@ describe("ProfilePage tests", () => {
         );
 
         expect(await screen.findByText("Phillip Conrad")).toBeInTheDocument();
-        expect(screen.getByText("phtcon@ucsb.edu")).toBeInTheDocument();
+        expect(screen.getAllByText("phtcon@ucsb.edu")[1]).toBeInTheDocument();
         expect(screen.getByTestId("role-badge-user")).toBeInTheDocument();
         expect(screen.getByTestId("role-badge-member")).toBeInTheDocument();
         expect(screen.getByTestId("role-badge-admin")).toBeInTheDocument();


### PR DESCRIPTION
This PR changes the user profile page at /profile to show user data in a table instead of a raw JSON.
[Link to Storybook page](https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-1/prs/27/storybook/?path=/story/components-userprofiletable--sample)

Before: 
![Before](https://user-images.githubusercontent.com/92177225/240430274-0768f55d-077b-4769-8ebf-6d2379180e1b.png)

After:
![After](https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-1/assets/92177225/62d002d5-ef03-4a26-8edc-7362e4f223f6)

Closes #13 
