### PR TITLE
ag - added current milk price to user frontend

### DIFF
--- a/frontend/src/main/components/Commons/ManageCows.js
+++ b/frontend/src/main/components/Commons/ManageCows.js
@@ -12,6 +12,7 @@ const ManageCows = ({userCommons,commons, onBuy, onSell}) =>  {
             {/* change $10 to info from fixture */}
             <Card.Title>Market Cow Price: ${commons?.cowPrice}</Card.Title>
             <Card.Title>Number of Cows: {userCommons.numOfCows}</Card.Title>
+            <Card.Title>Current Milk Price: ${commons?.milkPrice}</Card.Title>
                 <Row>
                     <Col>
                         <Card.Text>

--- a/frontend/src/stories/components/Commons/ManageCows.stories.mdx
+++ b/frontend/src/stories/components/Commons/ManageCows.stories.mdx
@@ -18,6 +18,6 @@ For a particular user's commons, the box where you buy and sell your cows.
 
 <Canvas>
   <Story name="uncontrolled">
-    <ManageCows userCommons = {userCommonsFixtures.oneUserCommons[0]} onBuy={(userCommons) => { console.log("onBuy called:",userCommons); }} onSell={ (userCommons) => { console.log("onSell called:",userCommons); }} />
+    <ManageCows commons = {commonsFixtures.oneCommons[0]} userCommons = {userCommonsFixtures.oneUserCommons[0]} onBuy={(userCommons) => { console.log("onBuy called:",userCommons); }} onSell={ (userCommons) => { console.log("onSell called:",userCommons); }} />
   </Story>
 </Canvas>

--- a/frontend/src/stories/components/Commons/ManageCows.stories.mdx
+++ b/frontend/src/stories/components/Commons/ManageCows.stories.mdx
@@ -18,6 +18,6 @@ For a particular user's commons, the box where you buy and sell your cows.
 
 <Canvas>
   <Story name="uncontrolled">
-    <ManageCows commons = {commonsFixtures.oneCommons[0]} userCommons = {userCommonsFixtures.oneUserCommons[0]} onBuy={(userCommons) => { console.log("onBuy called:",userCommons); }} onSell={ (userCommons) => { console.log("onSell called:",userCommons); }} />
+    <ManageCows commons =  {commonsFixtures.oneCommons[0]} userCommons = {userCommonsFixtures.oneUserCommons[0]} onBuy={(userCommons) => { console.log("onBuy called:",userCommons); }} onSell={ (userCommons) => { console.log("onSell called:",userCommons); }} />
   </Story>
 </Canvas>


### PR DESCRIPTION
In this PR, we tweaked the front end and storybook to display the current milk price of the commons that the user is currently in.
Storybook:

[Before](https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-1/storybook/?path=/story/components-commons-managecows--uncontrolled)
[After](https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-1/prs/29/storybook/?path=/story/components-commons-managecows--uncontrolled)

Before:
![Screenshot_20230605_184325](https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-1/assets/92177225/aab4fd55-a104-4b43-9d37-1efc0216c7c7)

After:
<img width="1161" alt="Screenshot 2023-06-04 at 6 22 34 PM" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-1/assets/114529890/4fc02e1d-b357-4710-a991-64965f5daeb7">
