### PR TITLE
Fix profit table overflow

### DIFF
--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -4,7 +4,12 @@ import { Table, Button } from "react-bootstrap";
 import Plaintext from "main/components/Utils/Plaintext";
 // Stryker disable all
 var tableStyle = {
-  "background": "white"
+  "background": "white",
+  "display": "block" ,
+  "max-width": "-moz-fit-content" ,
+  "margin": "0 auto" ,
+  "overflow-x": "auto" ,
+  "white-space": "nowrap"
 };
 // Stryker enable all
 export default function OurTable({ columns, data, testid = "testid", ...rest }) {


### PR DESCRIPTION
In this PR, we changed the table style in order to support horizontal scrolling, and to prevent the table from overflowing.
Before:
<img width="851" alt="Screenshot 2023-05-30 at 3 22 41 PM" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-1/assets/114529890/f9fa7bc8-b536-4d36-9497-278ac1082ce2">
After:
<img width="852" alt="Screenshot 2023-05-30 at 3 22 02 PM" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-1/assets/114529890/765fac37-2825-4cb9-8a56-513eacfdbf80">

Before: https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-1/storybook/?path=/story/components-commons-profitstable--emptytable
After: https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-1/prs/31/storybook/?path=/story/components-commons-profitstable--emptytable