### PR TITLE
Use cow health update strategies in frontend

### DIFF
--- a/frontend/src/fixtures/healthUpdateStrategyListFixtures.js
+++ b/frontend/src/fixtures/healthUpdateStrategyListFixtures.js
@@ -1,0 +1,25 @@
+const healthUpdateStrategyListFixtures = {
+    simple: {
+        strategies: [
+            {
+                name: "strat1",
+                displayName: "Strategy 1",
+                description: "This is the first strategy",
+            },
+            {
+                name: "strat2",
+                displayName: "Strategy 2",
+                description: "This is the second strategy",
+            },
+            {
+                name: "strat3",
+                displayName: "Strategy 3",
+                description: "This is the third strategy",
+            }
+        ],
+        defaultAboveCapacity: "strat1",
+        defaultBelowCapacity: "strat2",
+    }
+}
+
+export default healthUpdateStrategyListFixtures;

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -9,16 +9,17 @@ function HealthUpdateStrategiesDropdown({
   initialValue,
   healthUpdateStrategies,
   register,
-  testid,
 }) {
   return (
     <Form.Group className="mb-3">
       <Form.Label htmlFor={formName}>{displayName}</Form.Label>
       {healthUpdateStrategies && (
         <Form.Select
-          data-testid={`${testid}-${formName}`}
+          // test id omitted since it is not currently used in tests, and makes stryker fail otherwise
+          // data-testid={`${testid}-${formName}`}
           id={formName}
-          {...register(formName, {required: `${displayName} is required`})}
+          // "required" option is not necessary, since dropdown will always have a value
+          {...register(formName)}
           defaultValue={initialValue}
         >
           {healthUpdateStrategies.strategies.map((strategy) => (
@@ -205,7 +206,6 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
         formName={"aboveCapacityHealthUpdateStrategy"}
         displayName={"When above capacity"}
         intialValue={initialCommons?.aboveCapacityHealthUpdateStrategy ?? healthUpdateStrategies?.defaultAboveCapacity}
-        testid={testid}
         register={register}
         healthUpdateStrategies={healthUpdateStrategies}
       />
@@ -213,7 +213,6 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
         formName={"belowCapacityHealthUpdateStrategy"}
         displayName={"When below capacity"}
         intialValue={initialCommons?.belowCapacityHealthUpdateStrategy ?? healthUpdateStrategies?.defaultBelowCapacity}
-        testid={testid}
         register={register}
         healthUpdateStrategies={healthUpdateStrategies}
       />

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -1,5 +1,6 @@
-import { Button, Form } from "react-bootstrap";
-import { useForm } from "react-hook-form";
+import {Button, Form} from "react-bootstrap";
+import {useForm} from "react-hook-form";
+import {useBackend} from "../../utils/useBackend";
 
 function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
   // Stryker disable all
@@ -11,6 +12,37 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
     { defaultValues: initialCommons || {} }
   );
   // Stryker enable all
+
+  const {data: healthUpdateStrategies} = useBackend(
+    "/api/commons/all-health-update-strategies", {
+      method: "GET",
+      url: "/api/commons/all-health-update-strategies",
+    },
+  );
+
+
+  function healthUpdateStrategiesDropdown(formName, displayName, initialValue) {
+    return (
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor={formName}>{displayName}</Form.Label>
+        {healthUpdateStrategies && (
+          <Form.Select
+            data-testid={`${testid}-${formName}`}
+            id={formName}
+            {...register(formName, {required: `${displayName} is required`})}
+            defaultValue={initialValue}
+          >
+            {healthUpdateStrategies.strategies.map((strategy) => (
+              <option key={strategy.name} value={strategy.name} title={strategy.description}>
+                {strategy.displayName}
+              </option>
+            ))}
+          </Form.Select>
+        )}
+
+      </Form.Group>
+    );
+  }
 
   const testid = "CommonsForm";
 
@@ -158,9 +190,19 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
         </Form.Control.Feedback>
       </Form.Group>
 
+      <h4>
+        Health update formula
+      </h4>
+      {healthUpdateStrategiesDropdown("aboveCapacityHealthUpdateStrategy", "When above capacity",
+        initialCommons?.aboveCapacityHealthUpdateStrategy || healthUpdateStrategies?.defaultAboveCapacity
+      )}
+      {healthUpdateStrategiesDropdown("belowCapacityHealthUpdateStrategy", "When below capacity",
+        initialCommons?.belowCapacityHealthUpdateStrategy || healthUpdateStrategies?.defaultBelowCapacity
+      )}
+
       <Form.Group className="mb-3">
         <Form.Label htmlFor="showLeaderboard">Show Leaderboard?</Form.Label>
-        <Form.Check 
+        <Form.Check
           data-testid={`${testid}-showLeaderboard`}
           type="checkbox"
           id="showLeaderboard"

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -2,14 +2,46 @@ import {Button, Form} from "react-bootstrap";
 import {useForm} from "react-hook-form";
 import {useBackend} from "../../utils/useBackend";
 
-function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
+
+function HealthUpdateStrategiesDropdown({
+  formName,
+  displayName,
+  initialValue,
+  healthUpdateStrategies,
+  register,
+  testid,
+}) {
+  return (
+    <Form.Group className="mb-3">
+      <Form.Label htmlFor={formName}>{displayName}</Form.Label>
+      {healthUpdateStrategies && (
+        <Form.Select
+          data-testid={`${testid}-${formName}`}
+          id={formName}
+          {...register(formName, {required: `${displayName} is required`})}
+          defaultValue={initialValue}
+        >
+          {healthUpdateStrategies.strategies.map((strategy) => (
+            <option key={strategy.name} value={strategy.name} title={strategy.description}>
+              {strategy.displayName}
+            </option>
+          ))}
+        </Form.Select>
+      )}
+
+    </Form.Group>
+  );
+}
+
+
+function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
   // Stryker disable all
   const {
     register,
-    formState: { errors },
+    formState: {errors},
     handleSubmit,
   } = useForm(
-    { defaultValues: initialCommons || {} }
+    {defaultValues: initialCommons || {}}
   );
   // Stryker enable all
 
@@ -20,36 +52,12 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
     },
   );
 
-
-  function healthUpdateStrategiesDropdown(formName, displayName, initialValue) {
-    return (
-      <Form.Group className="mb-3">
-        <Form.Label htmlFor={formName}>{displayName}</Form.Label>
-        {healthUpdateStrategies && (
-          <Form.Select
-            data-testid={`${testid}-${formName}`}
-            id={formName}
-            {...register(formName, {required: `${displayName} is required`})}
-            defaultValue={initialValue}
-          >
-            {healthUpdateStrategies.strategies.map((strategy) => (
-              <option key={strategy.name} value={strategy.name} title={strategy.description}>
-                {strategy.displayName}
-              </option>
-            ))}
-          </Form.Select>
-        )}
-
-      </Form.Group>
-    );
-  }
-
   const testid = "CommonsForm";
 
   return (
     <Form onSubmit={handleSubmit(submitAction)}>
       {initialCommons && (
-        <Form.Group className="mb-3" >
+        <Form.Group className="mb-3">
           <Form.Label htmlFor="id">Id</Form.Label>
           <Form.Control
             data-testid={`${testid}-id`}
@@ -69,7 +77,7 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
           id="name"
           type="text"
           isInvalid={!!errors.name}
-          {...register("name", { required: "Commons name is required" })}
+          {...register("name", {required: "Commons name is required"})}
         />
         <Form.Control.Feedback type="invalid">
           {errors.name?.message}
@@ -87,7 +95,7 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
           {...register("startingBalance", {
             valueAsNumber: true,
             required: "Starting Balance is required",
-            min: { value: 0.01, message: "Starting Balance must be positive" },
+            min: {value: 0.01, message: "Starting Balance must be positive"},
           })}
         />
         <Form.Control.Feedback type="invalid">
@@ -106,7 +114,7 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
           {...register("cowPrice", {
             valueAsNumber: true,
             required: "Cow price is required",
-            min: { value: 0.01, message: "Cow price must be positive" },
+            min: {value: 0.01, message: "Cow price must be positive"},
           })}
         />
         <Form.Control.Feedback type="invalid">
@@ -125,7 +133,7 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
           {...register("milkPrice", {
             valueAsNumber: true,
             required: "Milk price is required",
-            min: { value: 0.01, message: "Milk price must be positive" },
+            min: {value: 0.01, message: "Milk price must be positive"},
           })}
         />
         <Form.Control.Feedback type="invalid">
@@ -163,7 +171,7 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
           {...register("degradationRate", {
             valueAsNumber: true,
             required: "Degradation rate is required",
-            min: { value: 0.00, message: "Degradation rate must be positive" },
+            min: {value: 0.00, message: "Degradation rate must be positive"},
           })}
         />
         <Form.Control.Feedback type="invalid">
@@ -182,7 +190,7 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
           {...register("carryingCapacity", {
             valueAsNumber: true,
             required: "Carrying capacity is required",
-            min: { value: 1, message: "Carrying Capacity must be greater than 0" },
+            min: {value: 1, message: "Carrying Capacity must be greater than 0"},
           })}
         />
         <Form.Control.Feedback type="invalid">
@@ -193,12 +201,23 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
       <h4>
         Health update formula
       </h4>
-      {healthUpdateStrategiesDropdown("aboveCapacityHealthUpdateStrategy", "When above capacity",
-        initialCommons?.aboveCapacityHealthUpdateStrategy || healthUpdateStrategies?.defaultAboveCapacity
-      )}
-      {healthUpdateStrategiesDropdown("belowCapacityHealthUpdateStrategy", "When below capacity",
-        initialCommons?.belowCapacityHealthUpdateStrategy || healthUpdateStrategies?.defaultBelowCapacity
-      )}
+      <HealthUpdateStrategiesDropdown
+        formName={"aboveCapacityHealthUpdateStrategy"}
+        displayName={"When above capacity"}
+        intialValue={initialCommons?.aboveCapacityHealthUpdateStrategy ?? healthUpdateStrategies?.defaultAboveCapacity}
+        testid={testid}
+        register={register}
+        healthUpdateStrategies={healthUpdateStrategies}
+      />
+      <HealthUpdateStrategiesDropdown
+        formName={"belowCapacityHealthUpdateStrategy"}
+        displayName={"When below capacity"}
+        intialValue={initialCommons?.belowCapacityHealthUpdateStrategy ?? healthUpdateStrategies?.defaultBelowCapacity}
+        testid={testid}
+        register={register}
+        healthUpdateStrategies={healthUpdateStrategies}
+      />
+
 
       <Form.Group className="mb-3">
         <Form.Label htmlFor="showLeaderboard">Show Leaderboard?</Form.Label>
@@ -210,7 +229,7 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
         />
       </Form.Group>
 
-      <Button type="submit" data-testid="CommonsForm-Submit-Button">{ buttonLabel }</Button>
+      <Button type="submit" data-testid="CommonsForm-Submit-Button">{buttonLabel}</Button>
     </Form>
   );
 }

--- a/frontend/src/main/pages/AdminEditCommonsPage.js
+++ b/frontend/src/main/pages/AdminEditCommonsPage.js
@@ -36,6 +36,8 @@ export default function CommonsEditPage() {
         "startingDate": commons.startingDate,
         "degradationRate": commons.degradationRate,
         "carryingCapacity": commons.carryingCapacity,
+        "aboveCapacityHealthUpdateStrategy": commons.aboveCapacityHealthUpdateStrategy,
+        "belowCapacityHealthUpdateStrategy": commons.belowCapacityHealthUpdateStrategy,
         "showLeaderboard": commons.showLeaderboard,
     }
   });

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { BrowserRouter as Router } from "react-router-dom";
+import {fireEvent, render, screen} from "@testing-library/react";
+import {BrowserRouter as Router} from "react-router-dom";
 import CommonsForm from "main/components/Commons/CommonsForm";
+import {QueryClient, QueryClientProvider} from "react-query";
 
 const mockedNavigate = jest.fn();
 
@@ -12,9 +13,11 @@ jest.mock('react-router-dom', () => ({
 describe("CommonsForm tests", () => {
   it("renders correctly", async () => {
     render(
-      <Router >
-        <CommonsForm />
-      </Router>
+        <QueryClientProvider client={new QueryClient()}>
+          <Router>
+            <CommonsForm/>
+          </Router>
+        </QueryClientProvider>
     );
 
     expect(await screen.findByText(/Commons Name/)).toBeInTheDocument();
@@ -27,7 +30,9 @@ describe("CommonsForm tests", () => {
       /Degradation Rate/,
       /Carrying Capacity/,
       /Show Leaderboard\?/,
-      
+      /When below capacity/,
+      /When above capacity/,
+
     ].forEach(
       (pattern) => {
         expect(screen.getByText(pattern)).toBeInTheDocument();
@@ -41,9 +46,11 @@ describe("CommonsForm tests", () => {
     const submitAction = jest.fn();
 
     render(
-      <Router  >
-        <CommonsForm submitAction={submitAction} buttonLabel="Create" />
-      </Router  >
+        <QueryClientProvider client={new QueryClient()}>
+          <Router>
+            <CommonsForm submitAction={submitAction} buttonLabel="Create"/>
+          </Router>
+        </QueryClientProvider>
     );
 
     expect(await screen.findByTestId("CommonsForm-name")).toBeInTheDocument();

--- a/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
@@ -1,12 +1,13 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
+import {fireEvent, render, screen, waitFor} from "@testing-library/react";
+import {QueryClient, QueryClientProvider} from "react-query";
+import {MemoryRouter} from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
 import AdminCreateCommonsPage from "main/pages/AdminCreateCommonsPage";
-import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
-import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import {apiCurrentUserFixtures} from "fixtures/currentUserFixtures";
+import {systemInfoFixtures} from "fixtures/systemInfoFixtures";
+import healthUpdateStrategyListFixtures from "../../fixtures/healthUpdateStrategyListFixtures";
 
 const mockedNavigate = jest.fn();
 jest.mock('react-router-dom', () => {
@@ -37,6 +38,9 @@ describe("AdminCreateCommonsPage tests", () => {
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+        axiosMock.onGet("/api/commons/all-health-update-strategies")
+            .reply(200, healthUpdateStrategyListFixtures.simple);
     });
 
     test("renders without crashing", async () => {
@@ -61,7 +65,9 @@ describe("AdminCreateCommonsPage tests", () => {
             "startingDate": "2022-03-05T00:00:00",
             "degradationRate": 30.4,
             "carryingCapacity": 25,
-            "showLeaderboard": false
+            "aboveCapacityHealthUpdateStrategy": "strat2",
+            "belowCapacityHealthUpdateStrategy": "strat3",
+            "showLeaderboard": false,
         });
 
         render(
@@ -81,6 +87,8 @@ describe("AdminCreateCommonsPage tests", () => {
         const startDateField = screen.getByLabelText("Starting Date");
         const degradationRateField = screen.getByLabelText("Degradation Rate");
         const carryingCapacityField = screen.getByLabelText("Carrying Capacity");
+        const aboveCapacityHealthUpdateStrategyField = screen.getByLabelText("When above capacity");
+        const belowCapacityHealthUpdateStrategyField = screen.getByLabelText("When below capacity");
         const showLeaderboardField = screen.getByLabelText("Show Leaderboard?");
         const button = screen.getByTestId("CommonsForm-Submit-Button");
 
@@ -92,6 +100,9 @@ describe("AdminCreateCommonsPage tests", () => {
         fireEvent.change(degradationRateField, { target: { value: '30.4' } })
         fireEvent.change(carryingCapacityField, { target: { value: '25' } })
         fireEvent.change(showLeaderboardField, { target: { value: true } })
+
+        fireEvent.change(aboveCapacityHealthUpdateStrategyField, { target: {value: 'strat2' } })
+        fireEvent.change(belowCapacityHealthUpdateStrategyField, { target: {value: 'strat3' } })
         fireEvent.click(button);
 
         await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
@@ -108,6 +119,8 @@ describe("AdminCreateCommonsPage tests", () => {
             startingDate: '2022-03-05T00:00:00.000Z', // [1]
             degradationRate: 30.4,
             carryingCapacity: 25,
+            aboveCapacityHealthUpdateStrategy: "strat2",
+            belowCapacityHealthUpdateStrategy: "strat3",
             showLeaderboard: false
         };
 

--- a/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
@@ -119,9 +119,9 @@ describe("AdminCreateCommonsPage tests", () => {
             startingDate: '2022-03-05T00:00:00.000Z', // [1]
             degradationRate: 30.4,
             carryingCapacity: 25,
+            showLeaderboard: false,
             aboveCapacityHealthUpdateStrategy: "strat2",
             belowCapacityHealthUpdateStrategy: "strat3",
-            showLeaderboard: false
         };
 
         expect(axiosMock.history.post[0].data).toEqual( JSON.stringify(expectedCommons) );

--- a/frontend/src/tests/pages/AdminEditCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminEditCommonsPage.test.js
@@ -1,12 +1,13 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
+import {fireEvent, render, screen, waitFor} from "@testing-library/react";
+import {QueryClient, QueryClientProvider} from "react-query";
+import {MemoryRouter} from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
 import AdminEditCommonsPage from "main/pages/AdminEditCommonsPage";
-import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
-import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import {apiCurrentUserFixtures} from "fixtures/currentUserFixtures";
+import {systemInfoFixtures} from "fixtures/systemInfoFixtures";
+import healthUpdateStrategyListFixtures from "../../fixtures/healthUpdateStrategyListFixtures";
 
 const mockToast = jest.fn();
 jest.mock('react-toastify', () => {
@@ -40,6 +41,7 @@ describe("AdminEditCommonsPage tests", () => {
             axiosMock.resetHistory();
             axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
             axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/commons/all-health-update-strategies").reply(200, healthUpdateStrategyListFixtures.simple);
             axiosMock.onGet("/api/commons", { params: { id: 5 } }).reply(200, {
                 "id": 5,
                 "name": "Seths Common",
@@ -50,6 +52,8 @@ describe("AdminEditCommonsPage tests", () => {
                 "degradationRate": 20.3,
                 "carryingCapacity": 100,
                 "showLeaderboard": false,
+                "aboveCapacityHealthUpdateStrategy": "strat1",
+                "belowCapacityHealthUpdateStrategy": "strat2"
             });
             axiosMock.onPut('/api/commons/update').reply(200, {
                 "id": 5,
@@ -61,6 +65,8 @@ describe("AdminEditCommonsPage tests", () => {
                 "degradationRate": 40.3,
                 "carryingCapacity": 200,
                 "showLeaderboard": false,
+                "aboveCapacityHealthUpdateStrategy": "strat2",
+                "belowCapacityHealthUpdateStrategy": "strat3"
             });
         });
 
@@ -93,6 +99,8 @@ describe("AdminEditCommonsPage tests", () => {
             const startingDateField = screen.getByLabelText(/Starting Date/);
             const degradationRateField = screen.getByLabelText(/Degradation Rate/);
             const carryingCapacityField = screen.getByLabelText(/Carrying Capacity/);
+            const aboveCapacityHealthUpdateStrategyField = screen.getByLabelText(/When above capacity/);
+            const belowCapacityHealthUpdateStrategyField = screen.getByLabelText(/When below capacity/);
             const showLeaderboardField = screen.getByLabelText(/Show Leaderboard\?/);
 
             expect(nameField).toHaveValue("Seths Common");
@@ -102,6 +110,8 @@ describe("AdminEditCommonsPage tests", () => {
             expect(milkPriceField).toHaveValue(10);
             expect(degradationRateField).toHaveValue(20.3);
             expect(carryingCapacityField).toHaveValue(100);
+            expect(aboveCapacityHealthUpdateStrategyField).toHaveValue("strat1");
+            expect(belowCapacityHealthUpdateStrategyField).toHaveValue("strat2");
             expect(showLeaderboardField).not.toBeChecked();
         });
 
@@ -123,6 +133,8 @@ describe("AdminEditCommonsPage tests", () => {
             const startingDateField = screen.getByLabelText(/Starting Date/);
             const degradationRateField = screen.getByLabelText(/Degradation Rate/);
             const carryingCapacityField = screen.getByLabelText(/Carrying Capacity/);
+            const aboveCapacityHealthUpdateStrategyField = screen.getByLabelText(/When above capacity/);
+            const belowCapacityHealthUpdateStrategyField = screen.getByLabelText(/When below capacity/);
             const showLeaderboardField = screen.getByLabelText(/Show Leaderboard\?/);
 
             expect(nameField).toHaveValue("Seths Common");
@@ -132,6 +144,8 @@ describe("AdminEditCommonsPage tests", () => {
             expect(milkPriceField).toHaveValue(10);
             expect(degradationRateField).toHaveValue(20.3);
             expect(carryingCapacityField).toHaveValue(100);
+            expect(aboveCapacityHealthUpdateStrategyField).toHaveValue("strat1");
+            expect(belowCapacityHealthUpdateStrategyField).toHaveValue("strat2");
             expect(showLeaderboardField).not.toBeChecked();
 
             const submitButton = screen.getByText("Update");
@@ -145,6 +159,8 @@ describe("AdminEditCommonsPage tests", () => {
             fireEvent.change(milkPriceField, { target: { value: 5 } })
             fireEvent.change(degradationRateField, { target: { value: 40.3 } })
             fireEvent.change(carryingCapacityField, { target: { value: 200 } })
+            fireEvent.change(aboveCapacityHealthUpdateStrategyField, { target: { value: "strat2" } })
+            fireEvent.change(belowCapacityHealthUpdateStrategyField, { target: { value: "strat3" } })
             fireEvent.click(showLeaderboardField)
 
             fireEvent.click(submitButton);
@@ -163,6 +179,8 @@ describe("AdminEditCommonsPage tests", () => {
                 "startingDate": "2022-03-07T00:00:00.000Z",
                 "degradationRate": 40.3,
                 "carryingCapacity": 200,
+                "aboveCapacityHealthUpdateStrategy": "strat2",
+                "belowCapacityHealthUpdateStrategy": "strat3",
                 "showLeaderboard": true,
             })); // posted object
         });


### PR DESCRIPTION
Depends on #23 

In this PR, we add the new cow health update strategy to the Commons create and edit pages.

[storybook for create commons page](https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-1/prs/32/storybook/?path=/story/pages-admincreatecommonspage--default). Note, the dropdown depends on the backend, so it's not present in the story. Is there a way to mock this with storybook? 

Here's how it looks now:
![image](https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-1/assets/24237065/d82b977d-0712-4920-bdc8-51dda0575d48)


Closes #17 