### PR TITLE
Add job on backend for setting cow health for all users in a commons

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -22,6 +22,7 @@ import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.jobs.InstructorReportJob;
 import edu.ucsb.cs156.happiercows.jobs.MilkTheCowsJob;
 import edu.ucsb.cs156.happiercows.jobs.MilkTheCowsJobFactory;
+import edu.ucsb.cs156.happiercows.jobs.SetCowHealthJobFactory;
 import edu.ucsb.cs156.happiercows.jobs.TestJob;
 import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJob;
 import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJobFactory;
@@ -50,6 +51,9 @@ public class JobsController extends ApiController {
 
     @Autowired
     MilkTheCowsJobFactory milkTheCowsJobFactory;
+
+    @Autowired
+    SetCowHealthJobFactory setCowHealthJobFactory;
 
     @ApiOperation(value = "List all jobs")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -90,6 +94,17 @@ public class JobsController extends ApiController {
     ) { 
         JobContextConsumer updateCowHealthJob = updateCowHealthJobFactory.create();
         return jobService.runAsJob(updateCowHealthJob);
+    }
+
+    @ApiOperation(value = "Launch Job to Set Cow Health")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/launch/setcowhealth")
+    public Job setCowHealth( 
+        @ApiParam("commonsID") @RequestParam Long commonsID, 
+        @ApiParam("health") @RequestParam double health
+    ) { 
+        JobContextConsumer setCowHealthJob = setCowHealthJobFactory.create(commonsID, health);
+        return jobService.runAsJob(setCowHealthJob);
     }
 
     @ApiOperation(value = "Launch Job to Produce Instructor Report")

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -12,8 +12,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-
-
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJob.java
@@ -32,20 +32,27 @@ public class SetCowHealthJob implements JobContextConsumer {
         ctx.log("Setting cow health...");
 
         Optional<Commons> commons = commonsRepository.findById(commonsID);
-        Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.get().getId());
+        
 
         if (commons.isPresent()) {
             ctx.log("Commons " + commons.get().getName());
-        }
+
+            Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.get().getId());
         
-        for (UserCommons userCommons : allUserCommons) {
-            User user = userRepository.findById(userCommons.getUserId()).orElseThrow(()->new RuntimeException("Error calling userRepository.findById(" + userCommons.getUserId() + ")"));
-            ctx.log("User: " + user.getFullName() + ", numCows: " + userCommons.getNumOfCows() + ", cowHealth: " + userCommons.getCowHealth());
-            ctx.log(" old cow health: " + userCommons.getCowHealth() + ", new cow health: " + newCowHealth);
-            userCommons.setCowHealth(newCowHealth);
-            userCommonsRepository.save(userCommons);
+            for (UserCommons userCommons : allUserCommons) {
+                User user = userRepository.findById(userCommons.getUserId()).orElseThrow(()->new RuntimeException("Error calling userRepository.findById(" + userCommons.getUserId() + ")"));
+                ctx.log("User: " + user.getFullName() + ", numCows: " + userCommons.getNumOfCows() + ", cowHealth: " + userCommons.getCowHealth());
+                ctx.log(" old cow health: " + userCommons.getCowHealth() + ", new cow health: " + newCowHealth);
+                userCommons.setCowHealth(newCowHealth);
+                userCommonsRepository.save(userCommons);
+            }
+
+            ctx.log("Cow health has been set!");
+        }
+        else {
+            ctx.log(String.format("No commons found for id %d", commonsID));
         }
 
-        ctx.log("Cow health has been set!");
+       
     } 
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJob.java
@@ -1,0 +1,51 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+
+
+import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
+import java.util.Optional;
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import lombok.Getter;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class SetCowHealthJob implements JobContextConsumer {
+
+    private long commonsID;
+    private double newCowHealth;
+
+    @Getter
+    private CommonsRepository commonsRepository;
+    @Getter
+    private UserCommonsRepository userCommonsRepository;
+    @Getter
+    private UserRepository userRepository;
+
+    @Override
+    public void accept(JobContext ctx) throws Exception {
+        ctx.log("Setting cow health...");
+
+        Optional<Commons> commons = commonsRepository.findById(commonsID);
+        Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.get().getId());
+
+        if (commons.isPresent()) {
+            ctx.log("Commons " + commons.get().getName());
+        }
+        
+        for (UserCommons userCommons : allUserCommons) {
+            User user = userRepository.findById(userCommons.getUserId()).orElseThrow(()->new RuntimeException("Error calling userRepository.findById(" + userCommons.getUserId() + ")"));
+            ctx.log("User: " + user.getFullName() + ", numCows: " + userCommons.getNumOfCows() + ", cowHealth: " + userCommons.getCowHealth());
+            ctx.log(" old cow health: " + userCommons.getCowHealth() + ", new cow health: " + newCowHealth);
+            userCommons.setCowHealth(newCowHealth);
+            userCommonsRepository.save(userCommons);
+        }
+
+        ctx.log("Cow health has been set!");
+    } 
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobFactory.java
@@ -1,0 +1,31 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.happiercows.entities.jobs.Job;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class SetCowHealthJobFactory  {
+
+    @Autowired 
+    private CommonsRepository commonsRepository;
+  
+    @Autowired
+    private UserCommonsRepository userCommonsRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    public JobContextConsumer create(Long commonsID, double health) {
+        log.info("commonsRepository = " + commonsRepository);
+        log.info("userCommonsRepository = " + userCommonsRepository);
+        return new SetCowHealthJob(commonsID, health, commonsRepository, userCommonsRepository, userRepository);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
@@ -40,6 +40,7 @@ import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.repositories.jobs.JobsRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobService;
 import edu.ucsb.cs156.happiercows.jobs.MilkTheCowsJobFactory;
+import edu.ucsb.cs156.happiercows.jobs.SetCowHealthJobFactory;
 import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJobFactory;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
@@ -74,6 +75,9 @@ public class JobsControllerTests extends ControllerTestCase {
 
     @MockBean
     MilkTheCowsJobFactory milkTheCowsJobFactory;
+
+    @MockBean
+    SetCowHealthJobFactory setCowHealthJobFactory;
 
     @WithMockUser(roles = { "ADMIN" })
     @Test
@@ -225,6 +229,21 @@ public class JobsControllerTests extends ControllerTestCase {
     public void admin_can_launch_update_cow_health_job() throws Exception {
         // act
         MvcResult response = mockMvc.perform(post("/api/jobs/launch/updatecowhealth").with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        log.info("responseString={}", responseString);
+        Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+        assertNotNull(jobReturned.getStatus());
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void admin_can_launch_set_cow_health_job() throws Exception {
+        // act
+        MvcResult response = mockMvc.perform(post("/api/jobs/launch/setcowhealth?commonsID=1&health=20").with(csrf()))
                 .andExpect(status().isOk()).andReturn();
 
         // assert

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobFactoryTests.java
@@ -1,0 +1,45 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+
+@RestClientTest(SetCowHealthJobFactory.class)
+@AutoConfigureDataJpa
+public class SetCowHealthJobFactoryTests {
+
+    @MockBean
+    CommonsRepository commonsRepository;
+
+    @MockBean
+    UserCommonsRepository userCommonsRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @Autowired
+    SetCowHealthJobFactory setCowHealthJobFactory;
+
+    @Test
+    void test_create() throws Exception {
+
+        // Act
+        SetCowHealthJob setCowHealthJob = (SetCowHealthJob) setCowHealthJobFactory.create(117L,2.0);
+
+        // Assert
+        assertEquals(commonsRepository,setCowHealthJob.getCommonsRepository());
+        assertEquals(userCommonsRepository,setCowHealthJob.getUserCommonsRepository());
+        assertEquals(userRepository,setCowHealthJob.getUserRepository());
+
+    }
+}
+

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobTests.java
@@ -1,0 +1,205 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import edu.ucsb.cs156.happiercows.entities.jobs.Job;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.entities.User;
+
+import java.time.LocalDateTime;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+public class SetCowHealthJobTests {
+        @Mock
+        CommonsRepository commonsRepository;
+
+        @Mock
+        UserCommonsRepository userCommonsRepository;
+
+        @Mock
+        UserRepository userRepository;
+
+        private User user = User
+                        .builder()
+                        .id(1L)
+                        .fullName("Chris Gaucho")
+                        .email("cgaucho@example.org")
+                        .build();
+        
+        @Test
+        void test_log_output_success() throws Exception {
+
+                // Arrange
+
+                Job jobStarted = Job.builder().build();
+                JobContext ctx = new JobContext(null, jobStarted);
+
+                // Act
+                SetCowHealthJob setCowHealthJob = new SetCowHealthJob(117, 2, commonsRepository, userCommonsRepository, 
+                userRepository);
+                setCowHealthJob.accept(ctx);
+
+                // Assert
+                String expected = """
+                                Setting cow health...
+                                Cow health has been set!""";
+
+                assertEquals(expected, jobStarted.getLog());
+        }
+        
+
+        @Test
+        void test_updating_to_new_values_for_multiple() throws Exception {
+
+                // Arrange
+                Job jobStarted = Job.builder().build();
+                JobContext ctx = new JobContext(null, jobStarted);
+
+                UserCommons origUserCommons1 = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(1L)
+                                .commonsId(1L)
+                                .totalWealth(300)
+                                .numOfCows(5)
+                                .cowHealth(50)
+                                .build();
+
+                UserCommons origUserCommons2 = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(1L)
+                                .commonsId(1L)
+                                .totalWealth(300)
+                                .numOfCows(5)
+                                .cowHealth(50)
+                                .build();
+
+                UserCommons origUserCommons3 = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(1L)
+                                .commonsId(1L)
+                                .totalWealth(300)
+                                .numOfCows(5)
+                                .cowHealth(50)
+                                .build();
+
+                Commons testCommons = Commons
+                                .builder()
+                                .name("test commons")
+                                .id(117L)
+                                .cowPrice(10)
+                                .milkPrice(2)
+                                .startingBalance(300)
+                                .startingDate(LocalDateTime.now())
+                                .carryingCapacity(10)
+                                .degradationRate(0.01)
+                                .build();
+
+                UserCommons newUserCommons = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(1L)
+                                .commonsId(1L)
+                                .totalWealth(300 - testCommons.getCowPrice())
+                                .numOfCows(5)
+                                .cowHealth(2.0)
+                                .build();
+
+                UserCommons userCommonsTemp[] = { origUserCommons1, origUserCommons2, origUserCommons3 };
+                when(commonsRepository.findById(117L)).thenReturn(Optional.of(testCommons));
+                when(userCommonsRepository.findByCommonsId(testCommons.getId()))
+                                .thenReturn(Arrays.asList(userCommonsTemp));
+                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+                // Act
+                SetCowHealthJob setCowHealthJob = new SetCowHealthJob(117, 2, commonsRepository, userCommonsRepository, 
+                userRepository);                                
+                setCowHealthJob.accept(ctx);
+
+                // Assert
+
+                String expected = """
+                                Setting cow health...
+                                Commons test commons
+                                User: Chris Gaucho, numCows: 5, cowHealth: 50.0
+                                 old cow health: 50.0, new cow health: 2.0
+                                User: Chris Gaucho, numCows: 5, cowHealth: 50.0
+                                 old cow health: 50.0, new cow health: 2.0
+                                User: Chris Gaucho, numCows: 5, cowHealth: 50.0
+                                 old cow health: 50.0, new cow health: 2.0
+                                Cow health has been set!""";
+
+                assertEquals(expected, jobStarted.getLog());
+                assertEquals(origUserCommons1.getCowHealth(), newUserCommons.getCowHealth());
+                assertEquals(origUserCommons2.getCowHealth(), newUserCommons.getCowHealth());
+                assertEquals(origUserCommons3.getCowHealth(), newUserCommons.getCowHealth());
+        }
+
+        @Test
+        void test_throws_exception_when_getting_user_fails() throws Exception {
+
+                // Arrange
+                Job jobStarted = Job.builder().build();
+                JobContext ctx = new JobContext(null, jobStarted);
+
+                UserCommons origUserCommons = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(321L)
+                                .commonsId(1L)
+                                .totalWealth(300)
+                                .numOfCows(1)
+                                .cowHealth(10)
+                                .build();
+
+                Commons testCommons = Commons
+                                .builder()
+                                .id(117L)
+                                .name("test commons")
+                                .cowPrice(10)
+                                .milkPrice(2)
+                                .startingBalance(300)
+                                .startingDate(LocalDateTime.now())
+                                .carryingCapacity(100)
+                                .degradationRate(0.01)
+                                .build();
+
+                UserCommons userCommonsTemp[] = { origUserCommons };
+                when(commonsRepository.findById(117L)).thenReturn(Optional.of(testCommons));
+                when(userCommonsRepository.findByCommonsId(testCommons.getId()))
+                                .thenReturn(Arrays.asList(userCommonsTemp));
+                when(userRepository.findById(321L)).thenReturn(Optional.empty());
+
+                // Act
+                SetCowHealthJob setCowHealthJob = new SetCowHealthJob(117, 2, commonsRepository, userCommonsRepository, 
+                                userRepository);
+
+                RuntimeException thrown = Assertions.assertThrows(RuntimeException.class, () -> {
+                        // Code under test
+                        setCowHealthJob.accept(ctx);
+                });
+
+                Assertions.assertEquals("Error calling userRepository.findById(321)", thrown.getMessage());
+
+        }
+
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobTests.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -44,24 +45,33 @@ public class SetCowHealthJobTests {
                         .build();
         
         @Test
-        void test_log_output_success() throws Exception {
+        void error_msg_when_no_commons_found() throws Exception {
 
                 // Arrange
 
                 Job jobStarted = Job.builder().build();
                 JobContext ctx = new JobContext(null, jobStarted);
 
+                when(commonsRepository.findById(any())).thenReturn(Optional.empty());
+                
+                // Optional<Commons> commons = commonsRepository.findById(commonsID);
+                // Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.get().getId());
+
+                
                 // Act
-                SetCowHealthJob setCowHealthJob = new SetCowHealthJob(117, 2, commonsRepository, userCommonsRepository, 
+                SetCowHealthJob setCowHealthJob = new SetCowHealthJob(117L, 2.0, commonsRepository, userCommonsRepository, 
                 userRepository);
                 setCowHealthJob.accept(ctx);
 
                 // Assert
                 String expected = """
                                 Setting cow health...
-                                Cow health has been set!""";
+                                No commons found for id 117""";
 
                 assertEquals(expected, jobStarted.getLog());
+                
+      
+                
         }
         
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobTests.java
@@ -53,11 +53,7 @@ public class SetCowHealthJobTests {
                 JobContext ctx = new JobContext(null, jobStarted);
 
                 when(commonsRepository.findById(any())).thenReturn(Optional.empty());
-                
-                // Optional<Commons> commons = commonsRepository.findById(commonsID);
-                // Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.get().getId());
 
-                
                 // Act
                 SetCowHealthJob setCowHealthJob = new SetCowHealthJob(117L, 2.0, commonsRepository, userCommonsRepository, 
                 userRepository);
@@ -69,8 +65,6 @@ public class SetCowHealthJobTests {
                                 No commons found for id 117""";
 
                 assertEquals(expected, jobStarted.getLog());
-                
-      
                 
         }
         


### PR DESCRIPTION
In this PR, a job is added on the backend for setting the cow health for all users in a particular commons. The job expects a `commonsID` as well as a `health` value for it to work properly.