### PR TITLE
Adding Placeholder Instructor Report Button to Job Table

### DIFF
--- a/frontend/src/fixtures/jobsFixtures.js
+++ b/frontend/src/fixtures/jobsFixtures.js
@@ -95,6 +95,13 @@ const jobsFixtures = {
         "log": "Error updating cow health"
       }
     ],
+    formJob: {
+      "id":1,
+      "createdAt": "2022-11-13T19:49:58.097465-08:00",
+      "updatedAt": "2022-11-13T19:49:59.203879-08:00",
+      "status": "complete",
+      "log": "Generating Instructor Report\nReport has been generated!"
+    }
 };
 
 export default jobsFixtures;

--- a/frontend/src/main/components/Jobs/InstructorReportForm.js
+++ b/frontend/src/main/components/Jobs/InstructorReportForm.js
@@ -1,7 +1,7 @@
 import { Button, Form } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 
-function InstructorReportForm() {
+function InstructorReportForm( {submitAction} ) {
   const {
     handleSubmit,
   } = useForm(
@@ -11,6 +11,7 @@ function InstructorReportForm() {
     <Form onSubmit={handleSubmit(submitAction)}>
       <p>Click this button to generate an instructor report!</p>
       <Button type="submit" data-testid="InstructorReport-Submit-Button">Submit</Button>
-  </Form>
+    </Form>
   );
 }
+export default InstructorReportForm;

--- a/frontend/src/main/components/Jobs/InstructorReportForm.js
+++ b/frontend/src/main/components/Jobs/InstructorReportForm.js
@@ -1,8 +1,16 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+
 function InstructorReportForm() {
-    return (
-      <p>This will be the Instructor Report Function (coming soon)</p>
-    );
-  }
-  
-  export default InstructorReportForm;
-  
+  const {
+    handleSubmit,
+  } = useForm(
+  );
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      <p>Click this button to generate an instructor report!</p>
+      <Button type="submit" data-testid="InstructorReport-Submit-Button">Submit</Button>
+  </Form>
+  );
+}

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -89,6 +89,11 @@ const AdminJobsPage = () => {
         MilkTheCowsMutation.mutate();
     }
 
+    const submitInstuctorReportJob = async () => {
+        console.log("submitInstructorReportJob (wip)");
+        toast('Submitted Job: Instructor Report (wip)');
+    }
+
     const jobLaunchers = [
         {
             name: "Test Job",
@@ -104,7 +109,7 @@ const AdminJobsPage = () => {
         },
         {
             name: "Instructor Report",
-            form: <InstructorReportForm />
+            form: <InstructorReportForm submitAction={submitInstuctorReportJob}/>
         },
     ]
 

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -91,7 +91,7 @@ const AdminJobsPage = () => {
 
     const submitInstuctorReportJob = async () => {
         console.log("submitInstructorReportJob (wip)");
-        toast('Submitted Job: Instructor Report (wip)');
+        toast('Instructor report not yet implemented; coming soon');
     }
 
     const jobLaunchers = [

--- a/frontend/src/stories/components/Jobs/InstructorReportForm.stories.mdx
+++ b/frontend/src/stories/components/Jobs/InstructorReportForm.stories.mdx
@@ -1,0 +1,19 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { action } from "@storybook/addon-actions";
+import InstructorReportForm from "main/components/Jobs/InstructorReportForm";
+
+<Meta
+  title="components/Jobs/InstructorReportForm"
+  component={InstructorReportForm}
+/>
+
+# InstructorReportForm
+
+A button for creating an instructor report, with:
+* a line telling the user what the button does
+
+<Canvas>
+  <Story name="uncontrolled">
+    <InstructorReportForm submitAction={action("submit")} />
+  </Story>
+</Canvas>

--- a/frontend/src/tests/components/Jobs/InstructorReportForm.test.js
+++ b/frontend/src/tests/components/Jobs/InstructorReportForm.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { BrowserRouter as Router } from "react-router-dom";
 import InstructorReportForm from "main/components/Jobs/InstructorReportForm";
 import jobsFixtures from "fixtures/jobsFixtures";

--- a/frontend/src/tests/components/Jobs/InstructorReportForm.test.js
+++ b/frontend/src/tests/components/Jobs/InstructorReportForm.test.js
@@ -1,0 +1,24 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+import InstructorReportForm from "main/components/Jobs/InstructorReportForm";
+import jobsFixtures from "fixtures/jobsFixtures";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate
+}));
+
+describe("InstructorReportForm tests", () => {
+  it("button generates correctly", async () => {
+    render(
+      <Router  >
+        <InstructorReportForm jobs={jobsFixtures.formJob}/>
+      </Router  >
+    );
+    const submitButton = screen.getByTestId("InstructorReport-Submit-Button");
+    expect(submitButton).toBeInTheDocument();
+  });
+
+});

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -131,5 +131,26 @@ describe("AdminJobsPage tests", () => {
         expect(axiosMock.history.post[0].url).toBe("/api/jobs/launch/milkthecowjob");
     });
 
+    test("user can attempt to submit instructor report form job", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminJobsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText("Instructor Report")).toBeInTheDocument();
+
+        const InstructorReportJobButton = screen.getByText("Instructor Report");
+        expect(InstructorReportJobButton).toBeInTheDocument();
+        InstructorReportJobButton.click();
+
+        const submitButton = screen.getByTestId("InstructorReport-Submit-Button");
+
+        expect(submitButton).toBeInTheDocument();
+        submitButton.click();
+    });
+
 
 });


### PR DESCRIPTION
In this pr, I added a functional button to the instructor report accordion section of the job table within manage jobs, with a toast message. Relevant tests are updated for both the job page and form to accomodate.

You should be able to expand the dropdown menu in the job page and click the button for a toast message (telling you the actual job is work in progress)
[](url)
This pr is a sub issue of #43 

# Images #

## Before: ##
<img width="981" alt="image" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-1/assets/92063396/03b61434-0df4-4f45-97e4-b38d3c02627b">

## After: ##
<img width="981" alt="image" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-1/assets/92063396/effb6488-5389-473f-84b1-ac32427fecc4">

<img width="242" alt="image" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-1/assets/92063396/26017c4f-6336-4b2f-9243-59879183541b">

# Storybook #
[jobs (before)](https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-1/storybook/?path=/story/components-jobs-jobstable--emptytable)

[instructor form (after)](https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-1/prs/50/storybook/?path=/story/components-jobs-instructorreportform--uncontrolled)

