### PR TITLE
pc - fix default job schedule

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,6 +30,6 @@ spring.data.mongodb.uri=${MONGODB_URI:${env.MONGODB_URI:mongodb+srv://fakeUserna
 # Use https://crontab.guru/ to translate the expressions below
 # except that there is an additional field at the beginning for seconds
 
-app.updateCowHealth.cron=${UPDATE_COW_HEALTH_CRON:${env.UPDATE_COW_HEALTH_CRON:* * 0,12 * * *}}
-app.milkTheCows.cron=${MILK_THE_COWS_CRON:${env.MILK_THE_COWS_CRON:* * 4 * * *}}
+app.updateCowHealth.cron=${UPDATE_COW_HEALTH_CRON:${env.UPDATE_COW_HEALTH_CRON:0 0 0,12 * * *}}
+app.milkTheCows.cron=${MILK_THE_COWS_CRON:${env.MILK_THE_COWS_CRON:0 0 4 * * *}}
 


### PR DESCRIPTION
In this PR, we fix the default job schedule so that it doesn't launch the jobs every second of every minutes during the scheduled hour.