### PR TITLE
pc - add getter and setter for UserCommons id field

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
@@ -18,7 +18,7 @@ public class UserCommons {
     @EmbeddedId
     @JsonIgnore
     @Builder.Default
-    private final UserCommonsKey id = new UserCommonsKey();
+    private UserCommonsKey id = new UserCommonsKey();
 
     @MapsId("userId")
     @ManyToOne
@@ -53,5 +53,12 @@ public class UserCommons {
     @JsonInclude
     public long getCommonsId() {
         return commons.getId();
+    }
+
+    public void setId(UserCommonsKey id) {
+        this.id = id;
+    }
+     public UserCommonsKey getId() {
+        return this.id;
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/entities/UserCommonsTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/entities/UserCommonsTests.java
@@ -25,4 +25,24 @@ public class UserCommonsTests {
         assertEquals(5L, asMap.get("commonsId"));
         assertEquals(10L, asMap.get("userId"));
     }
+
+    @Test
+    void userCommons_setId() {
+        // arrange
+        var userCommons = UserCommons.builder()
+                .commons(Commons.builder().id(5L).build())
+                .user(User.builder().id(10L).build())
+                .cowHealth(50)
+                .totalWealth(100)
+                .build();
+        
+        // act 
+
+        var newUserCommonsKey = new UserCommonsKey(20L, 30L);
+        userCommons.setId(newUserCommonsKey);
+        
+        // assert again
+        assertEquals(newUserCommonsKey, userCommons.getId());
+
+    }
 }


### PR DESCRIPTION
In this PR, we add a setter/getter for the UserCommons id field.

This is needed to build the instructor report functionality.